### PR TITLE
chore(skill): bump version to 2.1.0

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Celopedia Skill


### PR DESCRIPTION
## Summary

Bumps the skill version from `2.0.0` → `2.1.0` so the release-tag workflow cuts a new `celopedia-skill-v2.1.0` tag and the two-stage MiniPay submission docs (merged in #2) ship to anyone installing via `npx skills add celo-org/celopedia-skills`.

Minor bump because #2 is additive — new Stage 1 intake section, new §8 Analytics, new AI Telegram support agent recommendation — without breaking changes to existing references.

## Test plan

- [ ] On merge, confirm the `Tag Skill Release` workflow runs and pushes a `celopedia-skill-v2.1.0` tag
- [ ] Confirm a fresh `npx skills add celo-org/celopedia-skills` install picks up the two-stage MiniPay docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)