### PR TITLE
fix(builder-guide): correct mainnet FeeCurrencyDirectory address

### DIFF
--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -55,10 +55,10 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 | USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
 | USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
 
-The `FeeCurrencyDirectory` contract at `0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF` governs the allowlist. Query it:
+The `FeeCurrencyDirectory` contract at `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` governs the allowlist. Query it:
 
 ```typescript
-const FEE_CURRENCY_DIRECTORY = "0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF";
+const FEE_CURRENCY_DIRECTORY = "0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276";
 const currencies = await publicClient.readContract({
   address: FEE_CURRENCY_DIRECTORY,
   abi: [{ name: "getCurrencies", type: "function", stateMutability: "view", inputs: [], outputs: [{ type: "address[]" }] }],


### PR DESCRIPTION
## What
The Mainnet **Allowed Fee Currencies** section in `builder-guide.md`
referenced the Celo Sepolia testnet `FeeCurrencyDirectory` address
(`0x9212Fb...`) in two places under a "(Mainnet)" heading:

- L58 (prose): "The `FeeCurrencyDirectory` contract at `0x9212Fb...` governs the allowlist."
- L61 (code): `const FEE_CURRENCY_DIRECTORY = "0x9212Fb...";`

Both should reference the mainnet address `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276`.

## Why it matters
Builders following either the prose or copy-pasting the code would
call `getCurrencies()` against a contract that has no code on chain
ID 42220 — the Sepolia `FeeCurrencyDirectory` address is not deployed
on Celo mainnet.

## Source of truth
- https://docs.celo.org/tooling/contracts/core-contracts (Celo Mainnet section)
- Cross-check inside this repo:
  - `builder-guide.md` L42 already uses the correct mainnet address
  - `network-info.md` L36 already uses the correct mainnet address
  - `contracts.md` L24 already uses the correct mainnet address
  - `contracts.md` L189 keeps the Sepolia address under the testnet table (unchanged, correct)

## Change
Two-line fix in `builder-guide.md` (prose at L58 + code constant at L61). No code or test changes needed.