### PR TITLE
docs(readme): add Claude Code install instructions (.agents vs .claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,38 @@ The comprehensive skill for building on Celo. Ecosystem intelligence, developer 
 
 ## Install
 
+For Codex and OpenClaw (installs to `.agents/skills/`):
+
 ```bash
 npx skills add celo-org/celopedia-skills
 ```
 
-Works with Claude Code, Codex, and OpenClaw.
+### Claude Code
+
+Claude Code only discovers skills under `.claude/skills/` (project) or
+`~/.claude/skills/` (user), so `npx skills add` alone is not enough.
+Pick one of:
+
+**Option A — symlink (keeps `.agents/` as the source of truth, recommended on macOS/Linux):**
+
+```bash
+npx skills add celo-org/celopedia-skills
+mkdir -p .claude
+ln -s ../.agents/skills .claude/skills
+```
+
+**Option B — install directly under `.claude/skills/`:**
+
+```bash
+mkdir -p .claude/skills
+git clone --depth 1 https://github.com/celo-org/celopedia-skills.git /tmp/celopedia
+cp -r /tmp/celopedia/skills/celopedia-skill .claude/skills/
+rm -rf /tmp/celopedia
+```
+
+Restart Claude Code after installing — creating a new top-level `.claude/`
+directory mid-session is not picked up live. Verify with `/skills` or by
+asking "what skills are available?".
 
 ## What it does
 


### PR DESCRIPTION
## What
Add Claude Code-specific install instructions to the README.

## Why
The current README recommends `npx skills add celo-org/celopedia-skills`
and states the skill works in Claude Code. The `npx skills add` command
installs to `.agents/skills/` (the cross-tool convention), but Claude
Code only natively discovers skills under `.claude/skills/` per
https://code.claude.com/docs/en/skills.

The result is that Claude Code users follow the README, run the install
command, and find the skill never activates — there is no error, just
silence. This has happened in practice (this PR is filed by a user who
hit it).

## Change
- Keep `npx skills add` as the path for Codex/OpenClaw
- Add a short Claude Code section with two install options:
  - **Option A** — symlink `.claude/skills` to `.agents/skills` (keeps cross-tool portability)
  - **Option B** — install directly under `.claude/skills/` via `git clone` + `cp`
- Note the Claude Code session restart requirement

Only the Install section is touched.