### PR TITLE
docs(grants): add Proof of Ship to Currently Live Programs

### DIFF
--- a/skills/celopedia-skill/references/grants-funding.md
+++ b/skills/celopedia-skill/references/grants-funding.md
@@ -10,6 +10,15 @@
 
 ## Currently Live Programs
 
+### Proof of Ship (Season 2)
+- **Type**: Monthly builder program for MiniApps on MiniPay (not a hackathon)
+- **Amount**: $5,000 USDT/month prize pool; max 2,000 USDT per project across the season
+- **Dates**: April 1 – June 30, 2026 (three monthly cycles)
+- **Host**: Celo Devs / Celo Public Goods (submissions on Talent App)
+- **Priority categories**: Games, Utility apps, X2Earn apps, AI Agents with MiniPay use cases
+- **Best for**: Builders shipping MiniApps with MiniPay hook on Celo mainnet (verified contract + open-source GitHub required)
+- **Links**: https://bit.ly/celo-proof-of-ship · https://talent.app/~/earn/celo-proof-of-ship
+
 ### Prezenti: Anchor Round
 - **Type**: Milestone-based grants
 - **Amount**: Up to 25K USD
@@ -93,6 +102,7 @@
 
 | Building... | Recommended Programs |
 |-------------|---------------------|
+| Building a MiniApp for MiniPay | Proof of Ship S2 ($5K/month, max 2K USDT/project) |
 | Any Celo project (milestone-based) | Prezenti Anchor Round (up to 25K) |
 | GoodDollar integration | GoodBuilders S3 ($50K G$) |
 | Venture-stage project | Celo Builder Fund ($25K cUSD) |


### PR DESCRIPTION
## What
Add Proof of Ship Season 2 (Apr–Jun 2026) to the **Currently Live
Programs** section of `grants-funding.md`, plus a matching row in
the Grant Matchmaking Guide.

## Why
Proof of Ship Season 2 is the currently active builder program per
the public campaign at https://bit.ly/celo-proof-of-ship — it runs
**April 1 – June 30, 2026** with $5,000 USDT/month in rewards from
Celo Public Goods (capped at 2,000 USDT per project across the
season).

The file only listed **Proof of Ship S1 (Aug-Dec 2025)** in Past
Programs, with nothing under Currently Live. A builder asking 'what
grants are live now' would miss the active S2 entirely.

PoS S2 is specifically focused on MiniApps for MiniPay, which makes
it a different entry point than Prezenti, the Builder Fund, or
Proof of Impact — so it belongs as a distinct entry, not a footnote
under another program.

## Change
- New entry under 'Currently Live Programs' with S2 specifics
  (dates, prize pool, priority categories, MiniApp focus, Talent
  App as the platform)
- New matchmaking row targeting MiniApp builders
- No existing entries removed or reordered

## Source
- https://bit.ly/celo-proof-of-ship (public Season 2 campaign page)
- https://talent.app/~/earn/celo-proof-of-ship (submission platform)

Consistent with the file's existing 'always fetch live state'
directive at the top — entry points to the campaign page as the
source of truth for current iteration details.