### PR TITLE
docs(minipay): add docs.minipay.xyz map + refresh deeplinks, remove Bando

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The skill lives at `skills/celopedia-skill/` and is organized into topic-grouped
 | [`odis-socialconnect.md`](skills/celopedia-skill/references/odis-socialconnect.md) | ODIS (PnP), OdisPayments, FederatedAttestations |
 | [`minipay-live-apps.md`](skills/celopedia-skill/references/minipay-live-apps.md) | Discovery snapshot: live Mini Apps, categories, country targeting |
 | [`minipay-requirements.md`](skills/celopedia-skill/references/minipay-requirements.md) | Two-stage MiniPay listing flow: Stage 1 intake form (`minipay.to/mini-apps`) and Stage 2 post-call readiness checklist |
+| [`minipay-docs-map.md`](skills/celopedia-skill/references/minipay-docs-map.md) | Page-by-page index of `docs.minipay.xyz` (getting started, guides, technical references, deeplinks) |
 
 ### Platform Features
 

--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # Celopedia Skill
@@ -78,7 +78,7 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 14M+ users.
 - **Live Mini Apps catalog** (snapshot): published discovery listings, categories, links, and **per-country targeting notes** — see `minipay-live-apps.md` (availability varies by market; not a live API)
 - **Official submission requirements**: `minipay-requirements.md` — listing is a **two-stage process**. Stage 1 is the public **intake form** at `https://minipay.to/mini-apps`; Stage 2 is the post-call **readiness form** (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA, etc.). Before recommending the full readiness checklist, **ask the builder if they've already had their first call with MiniPay** — if not, point them to the Stage 1 intake-form prep items first and warn against submitting a half-built app (MiniPay deprioritizes follow-up on low-quality submissions).
 
-**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`
+**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`)
 
 ### 5. AI Agent Builder
 
@@ -153,6 +153,7 @@ Chain IDs, RPCs, explorers, faucets, RPC limits (`eth_getLogs` block range), and
 | Protocol integration | Check `defi-protocols.md` |
 | Build / deploy / verify | Check `builder-guide.md`, `dev-templates.md` |
 | MiniPay development | Check `minipay-guide.md`, `minipay-templates.md` |
+| Specific MiniPay docs page (`docs.minipay.xyz/...`) | Look up in `minipay-docs-map.md` |
 | MiniPay submission / listing readiness | Check `minipay-requirements.md` — ask first if they've had their MiniPay call. If not → Stage 1 intake prep. If yes → full Stage 2 checklist. |
 | What Mini Apps are live / discovery ideas | Check `minipay-live-apps.md` (snapshot; country availability varies) |
 | ODIS / phone lookup / SocialConnect | Check `odis-socialconnect.md`, `minipay-guide.md`, `contracts.md` |

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -219,7 +219,6 @@ MiniPay is Celo's flagship stablecoin wallet, built into Opera Mini and also ava
 | App | Category | Description |
 |-----|----------|-------------|
 | BitGifty | Bill Payments | Stablecoin-powered bill payments (450K+ active users, 10+ countries) |
-| Bando | Vouchers & Bills | Local voucher and bill payment service |
 | Topcasters | Prediction Gaming | USDT-powered prediction market game (2.2M+ predictions, 138K+ users) |
 | Mdundo | Music Streaming | Africa's top music platform, subscriptions from $0.50 |
 | Gamifly | Gamified Rewards | Trivia and challenge app with stablecoin rewards |

--- a/skills/celopedia-skill/references/minipay-docs-map.md
+++ b/skills/celopedia-skill/references/minipay-docs-map.md
@@ -1,0 +1,119 @@
+# MiniPay Documentation Map
+
+> Source: https://docs.minipay.xyz/
+> Last updated: 2026-05-18
+
+Use this to find the right page in MiniPay's developer docs for any topic. Links go directly to `docs.minipay.xyz`.
+
+For the broader Celo docs map (chain, SDKs, contracts, governance), see `docs-map.md`. For the duplicate set of MiniPay quickstart pages hosted on `docs.celo.org`, see `docs-map.md` → _Build on MiniPay_.
+
+---
+
+## Getting Started
+
+| Topic | URL |
+|-------|-----|
+| Overview | https://docs.minipay.xyz/getting-started/overview.html |
+| Why MiniPay | https://docs.minipay.xyz/getting-started/why-minipay.html |
+| Availability (countries / platforms) | https://docs.minipay.xyz/getting-started/availability.html |
+| Quick Start | https://docs.minipay.xyz/getting-started/quick-start.html |
+
+## Installation
+
+| Topic | URL |
+|-------|-----|
+| Project setup | https://docs.minipay.xyz/getting-started/project-setup.html |
+| Setup with React | https://docs.minipay.xyz/getting-started/setup-react.html |
+| Test in MiniPay (on device) | https://docs.minipay.xyz/getting-started/test-in-minipay.html |
+| FAQ | https://docs.minipay.xyz/faq.html |
+
+## Guides
+
+| Topic | URL |
+|-------|-----|
+| Wallet connection (auto-connect, `window.ethereum.isMiniPay`) | https://docs.minipay.xyz/getting-started/wallet-connection.html |
+| UI & container | https://docs.minipay.xyz/getting-started/ui-and-container.html |
+| Smart contracts (reads, writes, batching, events) | https://docs.minipay.xyz/getting-started/smart-contracts.html |
+| Best practices (error handling, tx UX, security, performance) | https://docs.minipay.xyz/getting-started/best-practices.html |
+| Deployment | https://docs.minipay.xyz/getting-started/deployment.html |
+| Submit your Mini App | https://docs.minipay.xyz/getting-started/submit-your-miniapp.html |
+
+## Reference — Overview
+
+| Topic | URL |
+|-------|-----|
+| Technical references overview | https://docs.minipay.xyz/technical-references.html |
+| Deeplinks (canonical list) | https://docs.minipay.xyz/technical-references/deeplinks.html |
+
+## Reference — Wallet Operations
+
+| Topic | URL |
+|-------|-----|
+| Retrieve balance | https://docs.minipay.xyz/technical-references/retrieve-balance.html |
+| Send a transaction | https://docs.minipay.xyz/technical-references/send-transaction.html |
+| Gas estimation | https://docs.minipay.xyz/technical-references/gas-estimation.html |
+| Phone number lookup (ODIS / SocialConnect) | https://docs.minipay.xyz/technical-references/phone-number-lookup.html |
+
+## Reference — Custom Methods
+
+| Topic | URL |
+|-------|-----|
+| Overview | https://docs.minipay.xyz/technical-references/custom-methods/custom-methods.html |
+| Get exchange rate | https://docs.minipay.xyz/technical-references/custom-methods/get-exchange-rate.html |
+| Scan QR code | https://docs.minipay.xyz/technical-references/custom-methods/scan-qr-code.html |
+| Request contact | https://docs.minipay.xyz/technical-references/custom-methods/request-contact.html |
+
+## Deeplinks (host: `link.minipay.xyz`)
+
+> Source: https://docs.minipay.xyz/technical-references/deeplinks.html — fetch before shipping; the list is updated periodically.
+
+| Deeplink | URL | When to use |
+|----------|-----|-------------|
+| Add Cash | `https://link.minipay.xyz/add_cash` (optionally `?tokens=USDm,USDC,USDT`) | Low balance — redirect users to top up |
+| Open Mini App | `https://link.minipay.xyz/browse?url=xxx` | Deep-link into an approved Mini App from outside MiniPay |
+| MiniApps tab | `https://link.minipay.xyz/discover` | Jump to the discovery tab |
+| Transaction receipt | `https://link.minipay.xyz/receipt?tx=xxx[&celebrate]` | Show the receipt screen for a tx hash (optionally with celebration animation) |
+| User's QR code | `https://link.minipay.xyz/qr` | Open the user's own QR screen |
+| Invite friends | `https://link.minipay.xyz/invite_friends` | Trigger the invite flow |
+| Pockets / balance | `https://link.minipay.xyz/balance` | Open the user's Pockets screen |
+
+All deeplinks require MiniPay installed and the user logged in.
+
+## External: Build-on-MiniPay on docs.celo.org
+
+These are the same MiniPay topics mirrored under `docs.celo.org`. Both sets are canonical and stay in sync; either is fine to link from a Mini App project.
+
+| Topic | URL |
+|-------|-----|
+| Overview | https://docs.celo.org/build-on-celo/build-on-minipay/overview |
+| Quickstart | https://docs.celo.org/build-on-celo/build-on-minipay/quickstart |
+| Code Library | https://docs.celo.org/build-on-celo/build-on-minipay/code-library |
+| Deeplinks | https://docs.celo.org/build-on-celo/build-on-minipay/deeplinks |
+| Ngrok Setup (device testing) | https://docs.celo.org/build-on-celo/build-on-minipay/prerequisites/ngrok-setup |
+
+## Submission
+
+| Resource | URL |
+|----------|-----|
+| MiniPay intake form (Stage 1) | https://minipay.to/mini-apps |
+| Submission docs page | https://docs.minipay.xyz/getting-started/submit-your-miniapp.html |
+
+> Stage 1 = the public intake form. Stage 2 = the readiness form sent after the first call. Full checklist in `minipay-requirements.md`.
+
+---
+
+## Quick lookups
+
+| If you need… | Go to |
+|--------------|-------|
+| Auto-connect / `isMiniPay` detection | `wallet-connection.html` · `faq.html` Q5 |
+| Send a transaction | `technical-references/send-transaction.html` · `faq.html` Q7–Q8 |
+| Pay gas in a stablecoin (CIP-64 fee abstraction) | `technical-references/gas-estimation.html` · `faq.html` Q9 |
+| Phone → address lookup | `technical-references/phone-number-lookup.html` |
+| Read on-chain balances | `technical-references/retrieve-balance.html` · `faq.html` Q10 |
+| Supported tokens | `faq.html` Q11 |
+| Smart-contract reads / writes / batching | `getting-started/smart-contracts.html` · `faq.html` Q12 |
+| Test on a real device | `getting-started/test-in-minipay.html` · `faq.html` Q13 |
+| Submit for listing | `getting-started/submit-your-miniapp.html` · `faq.html` Q14 |
+| Add Cash deeplink (low-balance redirect) | `technical-references/deeplinks.html` |
+| Available countries & platforms | `getting-started/availability.html` |

--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -1,6 +1,10 @@
 # MiniPay Development Guide
 
-> Source: docs.celo.org/build-on-celo/build-on-minipay/*
+> Sources:
+> - MiniPay docs (canonical): https://docs.minipay.xyz/
+> - docs.celo.org mirror: https://docs.celo.org/build-on-celo/build-on-minipay/*
+>
+> For the full page-by-page index of `docs.minipay.xyz`, see `minipay-docs-map.md`.
 
 MiniPay is a non-custodial stablecoin wallet integrated into Opera Mini and available as a standalone app on Android and iOS. It's the fastest growing wallet in the Global South with 14M+ activations, 300M+ stablecoin transactions, available in 60+ countries.
 
@@ -290,11 +294,16 @@ This is part of MiniPay's submission requirements — see `minipay-requirements.
 
 ## Deeplinks
 
+Host: `link.minipay.xyz`. Full table with all current deeplinks is in `minipay-docs-map.md` → _Deeplinks_.
+
 | Deeplink | URL | Purpose |
 |----------|-----|---------|
-| Deposit (Add Cash) | `https://minipay.opera.com/add_cash` | Redirect users with low balance to top up |
+| Add Cash | `https://link.minipay.xyz/add_cash` (optionally `?tokens=USDm,USDC,USDT`) | Redirect users with low balance to top up |
+| Open Mini App | `https://link.minipay.xyz/browse?url=xxx` | Deep-link into an approved Mini App |
+| MiniApps tab | `https://link.minipay.xyz/discover` | Jump to the discovery tab |
+| Transaction receipt | `https://link.minipay.xyz/receipt?tx=xxx[&celebrate]` | Show a receipt screen for a tx hash |
 
-> **Canonical list:** `https://docs.minipay.xyz/technical-references/deeplinks.html#available-deeplinks` — fetch before shipping; MiniPay publishes new deeplinks periodically.
+> **Canonical list:** https://docs.minipay.xyz/technical-references/deeplinks.html — fetch before shipping; MiniPay publishes new deeplinks periodically.
 >
 > **UI copy:** label this action **Deposit** in buttons/messages — not "Add Cash", "Onramp", or "Buy". See `minipay-requirements.md` §3.
 

--- a/skills/celopedia-skill/references/minipay-live-apps.md
+++ b/skills/celopedia-skill/references/minipay-live-apps.md
@@ -1,5 +1,7 @@
 # MiniPay live Mini Apps (discovery catalog snapshot)
 
+> Canonical MiniPay developer docs: https://docs.minipay.xyz/ (page-by-page index in `minipay-docs-map.md`). This file is a **discovery-catalog snapshot**, not docs.
+>
 > **Snapshot source:** Opera MiniPay discovery export (`discover-mini-apps-export.csv`). **Point-in-time** list so developers can see categories and live-style products in the MiniPay ecosystem.
 >
 > **Last regenerated from export:** 2026-04-09 (run `python3 scripts/generate_minipay_live_apps.py <csv>` from repo root).

--- a/skills/celopedia-skill/references/minipay-requirements.md
+++ b/skills/celopedia-skill/references/minipay-requirements.md
@@ -1,14 +1,17 @@
 # MiniPay Submission Requirements
 
-> Source: Opera MiniPay "Build for MiniPay: Developer Requirements" (official PDF).
-> Last updated: 2026-05-13.
+> Sources:
+> - Opera MiniPay "Build for MiniPay: Developer Requirements" (official PDF)
+> - MiniPay docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html
+>
+> Last updated: 2026-05-18.
 
 Getting a Mini App listed in MiniPay is a **two-stage process**:
 
 1. **Intake form** — submit basic app info at `https://minipay.to/mini-apps`. If the app looks promising, the MiniPay team books a first call with you.
 2. **Readiness form** — after the first call, MiniPay sends a full readiness form. The checklist in Stage 2 below is what they will assess against.
 
-For how to build each piece, see `minipay-guide.md`, `minipay-templates.md`, and `minipay-scaffold-from-scratch.md`.
+For how to build each piece, see `minipay-guide.md`, `minipay-templates.md`, and `minipay-scaffold-from-scratch.md`. For the full canonical docs index, see `minipay-docs-map.md`.
 
 ---
 
@@ -72,17 +75,23 @@ Everything below is what MiniPay assesses against in the readiness form **after 
 
 ### 1. Seamless User Experience
 
-- **Zero-Click Connect** — do **not** show a "Connect Wallet" button inside MiniPay. Auto-retrieve the wallet address from `window.ethereum`. Pattern: `minipay-templates.md` §1; detection: `minipay-guide.md` → MiniPay Detection.
-- **No Message Signing** — do **not** prompt users to `personal_sign` or `eth_signTypedData` to access or authenticate. MiniPay does not support these methods. See `minipay-guide.md` → Important Constraints #4.
-- **Phone-First Identity** — **never display raw `0x…` addresses** as the primary identifier. Show the phone number (resolved via ODIS → FederatedAttestations), an app-specific alias, or a truncated form only as a secondary hint. Lookup flow: `odis-socialconnect.md` and `minipay-guide.md` → Phone Number → Address Resolution.
+> Docs: https://docs.minipay.xyz/getting-started/wallet-connection.html · https://docs.minipay.xyz/getting-started/best-practices.html
+
+- **Zero-Click Connect** — do **not** show a "Connect Wallet" button inside MiniPay. Auto-retrieve the wallet address from `window.ethereum`. Pattern: `minipay-templates.md` §1; detection: `minipay-guide.md` → MiniPay Detection; docs: https://docs.minipay.xyz/getting-started/wallet-connection.html.
+- **No Message Signing** — do **not** prompt users to `personal_sign` or `eth_signTypedData` to access or authenticate. MiniPay does not support these methods. See `minipay-guide.md` → Important Constraints #4 and the wallet-connection doc above.
+- **Phone-First Identity** — **never display raw `0x…` addresses** as the primary identifier. Show the phone number (resolved via ODIS → FederatedAttestations), an app-specific alias, or a truncated form only as a secondary hint. Lookup flow: `odis-socialconnect.md` and `minipay-guide.md` → Phone Number → Address Resolution; docs: https://docs.minipay.xyz/technical-references/phone-number-lookup.html.
 
 ### 2. Currency & Stablecoin Logic
 
-- **Token Support** — supported tokens are **USDT, USDC, and USDm only**. **Never display or require the CELO token**; MiniPay handles fees automatically via CIP-64 fee abstraction.
-- **Dynamic Adaptation** — adapt to the user's **preferred stablecoin** (the one they hold the most of). Working helper: `minipay-templates.md` §6 — Preferred Stablecoin Selection.
+> Docs: https://docs.minipay.xyz/technical-references/retrieve-balance.html · https://docs.minipay.xyz/technical-references/gas-estimation.html · https://docs.minipay.xyz/faq.html (Q9, Q11)
+
+- **Token Support** — supported tokens are **USDT, USDC, and USDm only**. **Never display or require the CELO token**; MiniPay handles fees automatically via CIP-64 fee abstraction. See `faq.html` Q11.
+- **Dynamic Adaptation** — adapt to the user's **preferred stablecoin** (the one they hold the most of). Working helper: `minipay-templates.md` §6 — Preferred Stablecoin Selection. Balance lookup: https://docs.minipay.xyz/technical-references/retrieve-balance.html.
 - **Graceful Degradation** — if your app only supports one stablecoin, show a clear explainer ("This app accepts USDC only. Swap in MiniPay first.") instead of a broken interface.
 
 ### 3. User-Facing Copy (strict)
+
+> Docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html · https://docs.minipay.xyz/getting-started/best-practices.html (Transaction UX)
 
 Replace crypto-jargon with user-friendly terms everywhere a real user sees them (buttons, tooltips, error messages, copy):
 
@@ -98,20 +107,26 @@ Replace crypto-jargon with user-friendly terms everywhere a real user sees them 
 
 ### 4. Technical Performance & Optimization
 
-- **Mobile-First Resolution** — the UI must be responsive and fully functional at **360w × 640h**. Use Chrome DevTools device mode to validate before submission.
+> Docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html · https://docs.minipay.xyz/getting-started/best-practices.html (Performance, User Experience) · https://docs.minipay.xyz/getting-started/deployment.html
+
+- **Mobile-First Resolution** — the UI must be responsive and fully functional at **360w × 640h** (the original requirements PDF; MiniPay's submission doc cites **360 × 720** as the minimum — design for the smaller and verify on both). Use Chrome DevTools device mode to validate before submission.
 - **Asset Optimization** — use **SVG or WebP** for images. Avoid PNG/JPG for anything larger than a few KB.
 - **Performance Benchmarking** — submit a **PageSpeed Insights** score (`https://pagespeed.web.dev`) for your production URL with the form. Aim for 90+ on mobile. Low scores block listing.
 - **Network Transparency** — provide a full manifest of every **URL, subdomain, and origin** your app calls (JS, CSS, fonts, RPCs, APIs). MiniPay reviews this for supply-chain risk.
 
 ### 5. Smart Contract Standards
 
+> Docs: https://docs.minipay.xyz/getting-started/smart-contracts.html
+
 - **Public Verification** — all your contract source code must be **verified on Celoscan** (`https://celoscan.io`) so users can inspect it. How-to: `builder-guide.md` → Verification.
 - **Transaction Samples** — for every user-facing method your app uses, provide a **sample transaction link on Celoscan** with the submission.
 
 ### 6. Integration & Support
 
-- **Code Guidelines** — use the patterns in this skill (`minipay-guide.md`, `minipay-templates.md`). They mirror the canonical MiniPay Developer Documentation.
-- **Low-Balance Handling** — when a user cannot complete an action because their balance is too low, **redirect to the MiniPay Deposit deeplink** rather than showing an error. Deeplink: `https://minipay.opera.com/add_cash`. Canonical deeplink list: `https://docs.minipay.xyz/technical-references/deeplinks.html#available-deeplinks` — fetch before shipping; new deeplinks are added periodically.
+> Docs: https://docs.minipay.xyz/technical-references/deeplinks.html · https://docs.minipay.xyz/getting-started/best-practices.html (Error Handling)
+
+- **Code Guidelines** — use the patterns in this skill (`minipay-guide.md`, `minipay-templates.md`). They mirror the canonical MiniPay Developer Documentation at https://docs.minipay.xyz/.
+- **Low-Balance Handling** — when a user cannot complete an action because their balance is too low, **redirect to the MiniPay Add Cash deeplink** rather than showing an error. Deeplink: `https://link.minipay.xyz/add_cash` (optionally `?tokens=USDm,USDC,USDT`). Canonical deeplink list: https://docs.minipay.xyz/technical-references/deeplinks.html — fetch before shipping; new deeplinks are added periodically.
 - **Dedicated Support** — provide an **in-app support link** reachable from inside the Mini App (header icon, footer, or settings). Accepted channels: Telegram, WhatsApp, email, or web support portal.
 - **SLA** — you must fix reported **critical issues within 24 hours**, or MiniPay will temporarily disable your listing.
 
@@ -127,6 +142,8 @@ Meeting the 24h SLA across a growing user base is hard with manual triage. A rec
 You stay in the loop as the human approver, but the agent handles intake, classification, and first-draft answers — which is what makes the 24h critical-fix SLA actually achievable.
 
 ### 7. Branding & Legal
+
+> Docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html (Legal and Branding)
 
 - **Clear Ownership** — display your app's **name and logo** prominently. It must be obvious to the user that the service is operated by your entity, not by MiniPay.
 - **Legal Links** — provide accessible links to your **Terms of Service** and **Privacy Policy** from inside the app (footer or settings screen). Required for listing.
@@ -159,11 +176,17 @@ Where to publish: a `/stats` page inside the Mini App (read-only, no wallet requ
 
 ## Deeplinks (MiniPay)
 
+> Canonical list: https://docs.minipay.xyz/technical-references/deeplinks.html — fetch this before shipping; MiniPay publishes new deeplinks periodically. Full mirror in `minipay-docs-map.md` → _Deeplinks_.
+
 | Deeplink | URL | When to use |
 |----------|-----|-------------|
-| Deposit (Add Cash) | `https://minipay.opera.com/add_cash` | Low balance; user needs to top up |
-
-> Canonical list: `https://docs.minipay.xyz/technical-references/deeplinks.html#available-deeplinks` — fetch this before shipping; MiniPay publishes new deeplinks periodically.
+| Add Cash | `https://link.minipay.xyz/add_cash` (optionally `?tokens=USDm,USDC,USDT`) | Low balance; user needs to top up |
+| Open Mini App | `https://link.minipay.xyz/browse?url=xxx` | Deep-link into an approved Mini App |
+| MiniApps tab | `https://link.minipay.xyz/discover` | Jump to the discovery tab |
+| Transaction receipt | `https://link.minipay.xyz/receipt?tx=xxx[&celebrate]` | Show a receipt screen for a tx hash |
+| User's QR code | `https://link.minipay.xyz/qr` | Open the user's own QR screen |
+| Invite friends | `https://link.minipay.xyz/invite_friends` | Trigger the invite flow |
+| Pockets / balance | `https://link.minipay.xyz/balance` | Open the user's Pockets screen |
 
 ---
 

--- a/skills/celopedia-skill/references/minipay-requirements.md
+++ b/skills/celopedia-skill/references/minipay-requirements.md
@@ -109,7 +109,7 @@ Replace crypto-jargon with user-friendly terms everywhere a real user sees them 
 
 > Docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html · https://docs.minipay.xyz/getting-started/best-practices.html (Performance, User Experience) · https://docs.minipay.xyz/getting-started/deployment.html
 
-- **Mobile-First Resolution** — the UI must be responsive and fully functional at **360w × 640h** (the original requirements PDF; MiniPay's submission doc cites **360 × 720** as the minimum — design for the smaller and verify on both). Use Chrome DevTools device mode to validate before submission.
+- **Mobile-First Resolution** — the UI must be responsive and fully functional at **360w × 640h**. This is the hard minimum from the readiness PDF, and the smaller of the two figures floating in MiniPay's public material — design and verify against 360 × 640. Use Chrome DevTools device mode to validate before submission.
 - **Asset Optimization** — use **SVG or WebP** for images. Avoid PNG/JPG for anything larger than a few KB.
 - **Performance Benchmarking** — submit a **PageSpeed Insights** score (`https://pagespeed.web.dev`) for your production URL with the form. Aim for 90+ on mobile. Low scores block listing.
 - **Network Transparency** — provide a full manifest of every **URL, subdomain, and origin** your app calls (JS, CSS, fonts, RPCs, APIs). MiniPay reviews this for supply-chain risk.

--- a/skills/celopedia-skill/references/minipay-scaffold-from-scratch.md
+++ b/skills/celopedia-skill/references/minipay-scaffold-from-scratch.md
@@ -2,6 +2,12 @@
 
 For builders who want a minimal Next.js setup without Celo Composer's monorepo / Hardhat scaffolding. Produces a single Next.js app ready for MiniPay testing on ngrok.
 
+> Pairs with the canonical MiniPay docs:
+> - Project setup: https://docs.minipay.xyz/getting-started/project-setup.html
+> - Setup with React: https://docs.minipay.xyz/getting-started/setup-react.html
+> - Wallet connection: https://docs.minipay.xyz/getting-started/wallet-connection.html
+> - Test in MiniPay: https://docs.minipay.xyz/getting-started/test-in-minipay.html
+
 > **When to use this vs Celo Composer:** Use Composer (`npx @celo/celo-composer@latest create -t minipay`) if you want batteries-included (Hardhat, Foundry config, pre-wired wagmi/RainbowKit, monorepo layout). Use this guide if you want a clean single-app repo or are integrating MiniPay into an existing Next.js project.
 
 ---

--- a/skills/celopedia-skill/references/minipay-templates.md
+++ b/skills/celopedia-skill/references/minipay-templates.md
@@ -1,6 +1,6 @@
 # MiniPay Code Templates
 
-Ready-to-use code for common Mini App patterns.
+Ready-to-use code for common Mini App patterns. Canonical reference docs: https://docs.minipay.xyz/ — full per-page index in `minipay-docs-map.md`.
 
 ## Contents
 
@@ -488,8 +488,9 @@ import { getPreferredStablecoin } from "@/lib/stablecoins";
 async function startPayment(userAddress: `0x${string}`) {
   const preferred = await getPreferredStablecoin(userAddress);
   if (!preferred) {
-    // Low balance — redirect to MiniPay Deposit (see minipay-requirements.md §6)
-    window.location.href = "https://minipay.opera.com/add_cash";
+    // Low balance — redirect to MiniPay Add Cash (see minipay-requirements.md §6)
+    // Canonical: https://docs.minipay.xyz/technical-references/deeplinks.html
+    window.location.href = "https://link.minipay.xyz/add_cash";
     return;
   }
   // Proceed with preferred.address + preferred.decimals as the charge token.


### PR DESCRIPTION
## Summary

Brings the MiniPay references in line with `docs.minipay.xyz` and the latest deeplink host.

**New file — `minipay-docs-map.md`:** page-by-page index of `docs.minipay.xyz` (Getting Started, Installation, Guides, Reference, Wallet Operations, Custom Methods, Deeplinks) plus a quick-lookup table mapping common tasks to specific doc pages. Modeled on `docs-map.md`.

**`minipay-requirements.md`:**
- Per-section `https://docs.minipay.xyz/...` links across §1–§7
- Stage 1 source line now references both the readiness PDF and `submit-your-miniapp.html`
- Deeplink table refreshed and migrated to new host `link.minipay.xyz` — added `browse`, `discover`, `receipt`, `qr`, `invite_friends`, `balance`
- §4 mobile resolution: kept `360×640` as the hard minimum from the readiness PDF (a hedge against the docs page's `360×720` was added in commit 1 and removed in commit 2 after confirmation)

**`minipay-guide.md`:** header now points at `docs.minipay.xyz` as canonical (with `docs.celo.org` as mirror); deeplink table refreshed with the new host.

**`minipay-templates.md`:** header link to docs; low-balance redirect code uses `https://link.minipay.xyz/add_cash`.

**`minipay-scaffold-from-scratch.md`:** header links to `project-setup`, `setup-react`, `wallet-connection`, `test-in-minipay`.

**`minipay-live-apps.md`:** clarified that the file is a discovery-catalog snapshot, not docs.

**`ecosystem.md`:** removed the Bando entry (no longer live).

**`SKILL.md`:** references `minipay-docs-map.md` in the MiniPay capability + Research Workflow table; version bump `2.1.0 → 2.2.0` so the release-tag workflow fires on merge.

**`README.md`:** lists `minipay-docs-map.md` in the structure table.

## Commits

- `7820c17` — docs.minipay.xyz mapping + inline links + deeplink host migration + Bando removal + version bump
- `16b38a9` — drop 360×720 hedge (360×640 confirmed as the hard minimum)

## Test plan

- [ ] Spot-check three random rows in `minipay-docs-map.md` resolve to live pages on `docs.minipay.xyz`
- [ ] Confirm the new deeplink table in `minipay-requirements.md` and `minipay-guide.md` matches https://docs.minipay.xyz/technical-references/deeplinks.html
- [ ] Confirm version bump (`2.2.0`) triggers the release-tag workflow on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)