### PR TITLE
Minipay fit: add builder guidance — app fit framework, SDK patterns, dev-templates callout

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -89,8 +89,9 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 16M+ users.
 - Scaffold options: **Celo Composer** (batteries-included) or **raw Next.js** (see `minipay-scaffold-from-scratch.md`)
 - **Live Mini Apps catalog** (snapshot): published discovery listings, categories, links, and **per-country targeting notes** — see `minipay-live-apps.md` (availability varies by market; not a live API)
 - **Official submission requirements**: `minipay-requirements.md` — listing is a **two-stage process**. Stage 1 is the public **intake form** at `https://minipay.to/mini-apps`; Stage 2 is the post-call **readiness form** (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA, etc.). Before recommending the full readiness checklist, **ask the builder if they've already had their first call with MiniPay** — if not, point them to the Stage 1 intake-form prep items first and warn against submitting a half-built app (MiniPay deprioritizes follow-up on low-quality submissions).
+- **App Fit & Priority Framework**: before building, use `minipay-app-fit.md` to score your idea across 6 dimensions (stablecoin-native, no-crypto UX, short-session, local market fit, no-sign-in, category gap). Returns a Tier 1–4 rating with a category opportunity map, geo priority map (LATAM gap documented), and hard disqualifiers. Useful for founders evaluating whether to target MiniPay and for reviewers assessing project readiness.
 
-**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`)
+**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`), `minipay-app-fit.md`
 
 ### 5. AI Agent Builder
 

--- a/skills/celopedia-skill/references/dev-templates.md
+++ b/skills/celopedia-skill/references/dev-templates.md
@@ -2,6 +2,16 @@
 
 Ready-to-use configuration and code snippets for building on Celo.
 
+> **Building a Mini App for MiniPay?**
+> This file covers general Celo dev setup (Foundry, Hardhat, viem, wagmi). For a MiniPay-specific
+> scaffold with detection, auto-connect, fee abstraction, and ngrok testing already wired, use:
+>
+> - `minipay-scaffold-from-scratch.md` — minimal Next.js + viem setup (recommended for Mini Apps)
+> - `minipay-templates.md` — copy-paste code for 6 common patterns (payments, balances, deeplinks)
+> - `minipay-app-fit.md` — scorecard to check if your idea is a good fit before you start building
+>
+> Or scaffold immediately with: `npx @celo/celo-composer@latest create -t minipay`
+
 ---
 
 ## Foundry Configuration

--- a/skills/celopedia-skill/references/minipay-app-fit.md
+++ b/skills/celopedia-skill/references/minipay-app-fit.md
@@ -1,0 +1,222 @@
+# MiniPay App Fit & Priority Framework
+
+> **Who this is for:** Founders and builders deciding whether to build a Mini App for MiniPay —
+> and how to prioritise effort if they do.
+>
+> **What it answers:** "Should I target MiniPay?", "How strong is my product-channel fit?",
+> "Which category gives me the best chance of listing?", and "What will block me before I even submit?"
+>
+> **Data sources:** `minipay-live-apps.md` (catalog snapshot) · `minipay-requirements.md`
+> (official submission checklist) · `minipay-guide.md` (technical constraints).
+
+---
+
+## 1. Who Is the MiniPay User?
+
+Before scoring your idea, know the person on the other end of the screen.
+
+| Dimension | Reality |
+|-----------|---------|
+| **Geography** | Global South — Nigeria, Kenya, Uganda, Ghana, South Africa, Brazil, Colombia, Philippines (60+ countries) |
+| **Device** | Budget Android (most common), basic iOS. Expect small screens, low RAM |
+| **Connectivity** | Intermittent, low bandwidth. 2G/3G is common in primary markets |
+| **Financial profile** | Unbanked or underbanked. Stablecoins serve as the primary savings and payment tool |
+| **Stablecoins available** | USDm, USDC, USDT only. CELO is hidden from users and handled automatically |
+| **Crypto literacy** | Non-crypto-native. Terms like "gas", "onramp", "wallet address", and "blockchain" are UX failures |
+| **Session length** | Short. Single-handed use on mobile, often in noisy or low-attention environments |
+
+**The core implication:** Apps that solve real-money problems (paying bills, earning income, sending money, accessing credit, saving) for non-crypto users win in MiniPay. Apps that require crypto knowledge, long forms, or heavy UI lose.
+
+---
+
+## 2. App Fit Scorecard
+
+Score your idea on 6 dimensions (0–2 each). Total out of 12.
+
+### A. Stablecoin-native
+Does the core value of your app involve sending, receiving, saving, or earning USDm / USDT / USDC?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | The core user flow is entirely in stablecoins — users earn, spend, or move USDm/USDT/USDC |
+| **1** | Stablecoins are present but secondary to the main experience |
+| **0** | The app does not involve stablecoin transactions at all |
+
+> **Note:** The CELO token must never appear in your UI. MiniPay handles network fees automatically via CIP-64 fee abstraction — see `builder-guide.md` → *Allowed Fee Currencies (Mainnet)*.
+
+---
+
+### B. No-crypto UX possible
+Can you build this without exposing blockchain concepts to the user?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | Users never see "wallet", "gas", "chain", "token", "smart contract", or a raw `0x…` address |
+| **1** | Some crypto vocabulary is visible but can be explained in plain language (e.g. "digital dollars") |
+| **0** | The app requires users to understand blockchain mechanics to complete the core flow |
+
+> MiniPay enforces specific copy rules. Replace: "Gas fee" → **Network fee** · "Onramp" → **Deposit** · "Offramp" → **Withdraw** · "Crypto" → **Stablecoin** or **Digital dollar**. See `minipay-requirements.md` §3.
+
+---
+
+### C. Short-session friendly
+Can the primary action be completed in under 60 seconds on a budget Android?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | Core action takes ≤ 3 taps, works reliably on a slow connection |
+| **1** | 4–7 steps, requires decent connectivity |
+| **0** | Multi-step flow, data-heavy UI, or complex input required |
+
+> Budget Android users on 3G have a very low tolerance for loading times and form friction. Every extra tap is potential churn. Keep the happy path ruthlessly short.
+
+---
+
+### D. Local market fit
+Does your app address a need that is acute in at least one of MiniPay's primary markets?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | Directly solves a known, documented pain point in a specific target market — describe which country and why |
+| **1** | Useful broadly but not specifically designed for Global South or emerging market users |
+| **0** | Designed primarily for users who already have banking infrastructure |
+
+**Example pain points by market:**
+
+| Country | Acute need |
+|---------|-----------|
+| 🇳🇬 Nigeria | Bill payment, airtime top-up, USD savings against naira inflation |
+| 🇰🇪 Kenya | Micro-savings, remittance corridors, small business payments |
+| 🇧🇷 Brazil | Credit access, PIX-equivalent instant payments, inflation hedging |
+| 🇨🇴 Colombia | Cross-border payments, gig worker payouts, USD savings |
+| 🇵🇭 Philippines | OFW remittances, informal lending, digital tipping |
+| 🇿🇦 South Africa | Informal savings groups (stokvels), township commerce |
+
+> **When filling this dimension:** name the specific country, the pain point, and why your app addresses it better than what already exists in that market.
+
+---
+
+### E. No-sign-in possible
+MiniPay does not support `personal_sign` or `eth_signTypedData`. Can your app work without them?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | Wallet address alone is sufficient identity — no off-chain auth required |
+| **1** | Needs phone-number → address resolution via ODIS / FederatedAttestations (supported, but adds setup complexity — see `odis-socialconnect.md`) |
+| **0** | Requires `personal_sign` or `eth_signTypedData` — **this is a hard technical block; the app cannot function in MiniPay** |
+
+> **Auto-connect is mandatory inside MiniPay.** Never show a "Connect Wallet" button when `window.ethereum.isMiniPay === true`. See `minipay-guide.md` → *Wallet Connection*.
+
+---
+
+### F. Category gap in current catalog
+Is your category underserved in the MiniPay Discovery catalog right now?
+
+| Score | What it means |
+|-------|---------------|
+| **2** | Category has 0–1 existing apps, or the one app that exists is geo-blocked in your target market |
+| **1** | 2–4 competitors, but your angle is meaningfully differentiated |
+| **0** | Saturated category (games: 11 apps, rewards: 10 apps) with no clear differentiation |
+
+> See `minipay-live-apps.md` for the current catalog snapshot with per-country availability data.
+
+---
+
+## 3. Priority Tiers
+
+| Total Score | Priority | What to do |
+|-------------|----------|------------|
+| **10–12** | 🟢 **Tier 1 — Build now** | Strong product-channel fit. Prioritise MiniPay Discovery as your primary distribution channel. After building, get a Celo team review before submitting. |
+| **7–9** | 🟡 **Tier 2 — Build with caveats** | Good fit with specific gaps. Identify your lowest-scoring dimension and address it before submission. |
+| **4–6** | 🟠 **Tier 3 — Validate first** | Partial fit. Run an ngrok test with real users in your target market before committing. Consider entering Proof of Ship to get feedback from the Celo community. |
+| **0–3** | 🔴 **Tier 4 — Wrong channel** | Structural mismatch with MiniPay constraints. Pivot the product concept or choose a different distribution channel. Proof of Ship is a good environment for this pivot. |
+
+---
+
+## 4. Category Opportunity Map
+
+Current catalog density from `minipay-live-apps.md` (snapshot — verify before using):
+
+| Category | Apps live | Opportunity | Notes |
+|----------|-----------|-------------|-------|
+| **Social** | 0 | 🟢 High | No social app listed. First mover in a 14M-wallet network |
+| **Finance — credit/lending** | 0 | 🟢 High | No credit app. Massive need in all primary markets |
+| **Finance — savings/FX** | 7 | 🟢 High | LATAM almost entirely uncovered |
+| **Prediction / betting** | 2 | 🟢 High | Main competitor (Predictor) blocked in BR, AR, GB, TH, VN, MY, PH |
+| **Shopping** | 1 | 🟢 High | Only one app. E-commerce + stablecoins is open |
+| **Health / fitness** | 1 | 🟢 High | Only Squadletics. Large green field |
+| **News / media** | 1 | 🟢 High | Only Briefing. Untapped |
+| **Games** | 11 | 🟡 Medium | Competitive, but novel mechanics (skill-based, local IP, cultural context) can still win |
+| **Rewards / earn** | 10 | 🔴 Saturated | Highest competition. Only enter with a structurally different earning mechanic |
+| **Utility** | 8 | 🟡 Medium | Bill pay dominated by Nigeria-focused apps. Other markets open |
+| **Sports** | 4 | 🟡 Medium | Africa-focused. LATAM sports app gap exists |
+
+---
+
+## 5. Geo Priority Map
+
+| Region | Countries | MiniPay penetration | Catalog coverage | Best categories to target |
+|--------|-----------|---------------------|-----------------|--------------------------|
+| **West Africa** | NG, GH, SL, CI | 🔴 High — most apps already here | Mostly covered | New mechanics in games, health, news |
+| **East Africa** | KE, UG, TZ, RW | 🟡 Medium | Partially covered | Finance, savings, sports |
+| **LATAM — Brazil** | BR | 🟢 Low | Almost nothing | Prediction, finance, social, shopping |
+| **LATAM — Andean** | CO, AR, PE, CL | 🟢 Low | Almost nothing | Prediction, finance, remittance |
+| **Southeast Asia** | PH, ID | 🟡 Medium | Partial | Remittance, micro-lending |
+| **Southern Africa** | ZA, MW, ZM | 🟢 Low | Almost nothing | Finance, savings, informal commerce |
+
+> **LATAM is the single biggest opportunity right now.** High MiniPay user base, almost no apps targeting the region, and the main prediction-market competitor is geo-blocked in Brazil and Argentina.
+
+---
+
+## 6. Automatic Disqualifiers
+
+These are hard technical constraints. They are **not fixable with UX changes** — they require architectural decisions before building.
+
+| Disqualifier | Why it blocks you |
+|---|---|
+| App requires `personal_sign` | MiniPay does not support this method. Any flow that needs off-chain signatures (login, permit, typed auth) will silently fail or error. |
+| App requires `eth_signTypedData` | Same as above — not supported by the MiniPay wallet. |
+| App displays CELO balance or requires CELO payment | MiniPay hides CELO from users entirely. Displaying it breaks the UX contract and will get your app rejected from Discovery. |
+| App only works with EIP-1559 transaction fields | MiniPay uses legacy transactions only. Do not set `maxFeePerGas` or `maxPriorityFeePerGas`. |
+| App can only be tested in an emulator | MiniPay requires a physical device running Android or iOS. If your team cannot test on-device, do not submit yet. |
+| Bundle size > 2 MB or heavy images | Low-bandwidth users will abandon. Use SVG/WebP, lazy-load aggressively, and keep your initial JS bundle small. |
+
+---
+
+## 7. Pre-fit Checklist (run before scoring)
+
+Before applying the scorecard, answer these questions. A single "No" on items 1–4 is an immediate Tier 4:
+
+- [ ] Can the entire core user flow run inside MiniPay's WebView without external app switching?
+- [ ] Does your app work without `personal_sign` or `eth_signTypedData`?
+- [ ] Can you build the UI without showing CELO or raw `0x…` addresses?
+- [ ] Is your app testable on a physical device via ngrok?
+- [ ] Can a non-crypto user understand what the app does from the first screen?
+
+---
+
+## 8. Example Score — Reference
+
+The table below shows a worked example for orientation. Replace with your own app's values.
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| A. Stablecoin-native | 2 | All payments and rewards denominated in USDm or USDT |
+| B. No-crypto UX | 2 | "Network fee" not "gas"; no addresses shown; no crypto jargon in UI copy |
+| C. Short-session | 2 | Core action (3 taps): choose → confirm → done |
+| D. Local market fit | 2 | Targets Brazil specifically; fills a gap left by a geo-blocked competitor |
+| E. No-sign-in | 2 | Wallet address = identity; no `personal_sign` anywhere |
+| F. Category gap | 2 | Category has zero Celo-native apps; main competitor geo-blocked |
+| **Total** | **12 / 12** | **🟢 Tier 1 — Build now** |
+
+---
+
+## Related References
+
+- `minipay-guide.md` — Detection, auto-connect, stablecoin transfers, deeplinks, ngrok testing
+- `minipay-requirements.md` — Official submission checklist (copy rules, PageSpeed, ToS/Privacy, SLA)
+- `minipay-live-apps.md` — Full catalog snapshot with country availability data
+- `minipay-templates.md` — Ready-to-copy code for common Mini App patterns
+- `minipay-scaffold-from-scratch.md` — Minimal Next.js + viem setup without Celo Composer
+- `odis-socialconnect.md` — Phone number → address resolution via ODIS / FederatedAttestations
+- `builder-guide.md` — Fee abstraction (CIP-64), feeCurrency adapter addresses, SDK selection

--- a/skills/celopedia-skill/references/minipay-app-fit.md
+++ b/skills/celopedia-skill/references/minipay-app-fit.md
@@ -31,7 +31,7 @@ Before scoring your idea, know the person on the other end of the screen.
 
 ## 2. App Fit Scorecard
 
-Score your idea on 6 dimensions (0–2 each). Total out of 12.
+Score your idea on 5 dimensions (0–2 each). Total out of 10.
 
 ### A. Stablecoin-native
 Does the core value of your app involve sending, receiving, saving, or earning USDm / USDT / USDC?
@@ -46,20 +46,7 @@ Does the core value of your app involve sending, receiving, saving, or earning U
 
 ---
 
-### B. No-crypto UX possible
-Can you build this without exposing blockchain concepts to the user?
-
-| Score | What it means |
-|-------|---------------|
-| **2** | Users never see "wallet", "gas", "chain", "token", "smart contract", or a raw `0x…` address |
-| **1** | Some crypto vocabulary is visible but can be explained in plain language (e.g. "digital dollars") |
-| **0** | The app requires users to understand blockchain mechanics to complete the core flow |
-
-> MiniPay enforces specific copy rules. Replace: "Gas fee" → **Network fee** · "Onramp" → **Deposit** · "Offramp" → **Withdraw** · "Crypto" → **Stablecoin** or **Digital dollar**. See `minipay-requirements.md` §3.
-
----
-
-### C. Short-session friendly
+### B. Short-session friendly
 Can the primary action be completed in under 60 seconds on a budget Android?
 
 | Score | What it means |
@@ -72,7 +59,7 @@ Can the primary action be completed in under 60 seconds on a budget Android?
 
 ---
 
-### D. Local market fit
+### C. Local market fit
 Does your app address a need that is acute in at least one of MiniPay's primary markets?
 
 | Score | What it means |
@@ -96,7 +83,7 @@ Does your app address a need that is acute in at least one of MiniPay's primary 
 
 ---
 
-### E. No-sign-in possible
+### D. No-sign-in possible
 MiniPay does not support `personal_sign` or `eth_signTypedData`. Can your app work without them?
 
 | Score | What it means |
@@ -109,14 +96,14 @@ MiniPay does not support `personal_sign` or `eth_signTypedData`. Can your app wo
 
 ---
 
-### F. Category gap in current catalog
+### E. Category gap in current catalog
 Is your category underserved in the MiniPay Discovery catalog right now?
 
 | Score | What it means |
 |-------|---------------|
 | **2** | Category has 0–1 existing apps, or the one app that exists is geo-blocked in your target market |
 | **1** | 2–4 competitors, but your angle is meaningfully differentiated |
-| **0** | Saturated category (games: 11 apps, rewards: 10 apps) with no clear differentiation |
+| **0** | Highly competitive category with no clear differentiation angle |
 
 > See `minipay-live-apps.md` for the current catalog snapshot with per-country availability data.
 
@@ -126,10 +113,10 @@ Is your category underserved in the MiniPay Discovery catalog right now?
 
 | Total Score | Priority | What to do |
 |-------------|----------|------------|
-| **10–12** | 🟢 **Tier 1 — Build now** | Strong product-channel fit. Prioritise MiniPay Discovery as your primary distribution channel. After building, get a Celo team review before submitting. |
-| **7–9** | 🟡 **Tier 2 — Build with caveats** | Good fit with specific gaps. Identify your lowest-scoring dimension and address it before submission. |
-| **4–6** | 🟠 **Tier 3 — Validate first** | Partial fit. Run an ngrok test with real users in your target market before committing. Consider entering Proof of Ship to get feedback from the Celo community. |
-| **0–3** | 🔴 **Tier 4 — Wrong channel** | Structural mismatch with MiniPay constraints. Pivot the product concept or choose a different distribution channel. Proof of Ship is a good environment for this pivot. |
+| **8–10** | 🟢 **Tier 1 — Build now** | Strong product-channel fit. Prioritise MiniPay Discovery as your primary distribution channel. After building, get a Celo team review before submitting. |
+| **5–7** | 🟡 **Tier 2 — Build with caveats** | Good fit with specific gaps. Identify your lowest-scoring dimension and address it before submission. |
+| **3–4** | 🟠 **Tier 3 — Validate first** | Partial fit. Run an ngrok test with real users in your target market before committing. Consider entering Proof of Ship to get feedback from the Celo community. |
+| **0–2** | 🔴 **Tier 4 — Wrong channel** | Structural mismatch with MiniPay constraints. Pivot the product concept or choose a different distribution channel. Proof of Ship is a good environment for this pivot. |
 
 ---
 
@@ -141,73 +128,53 @@ Current catalog density from `minipay-live-apps.md` (snapshot — verify before 
 |----------|-----------|-------------|-------|
 | **Social** | 0 | 🟢 High | No social app listed. First mover in a 14M-wallet network |
 | **Finance — credit/lending** | 0 | 🟢 High | No credit app. Massive need in all primary markets |
-| **Finance — savings/FX** | 7 | 🟢 High | LATAM almost entirely uncovered |
-| **Prediction / betting** | 2 | 🟢 High | Main competitor (Predictor) blocked in BR, AR, GB, TH, VN, MY, PH |
+| **Finance — savings/FX** | 7 | 🟢 High | Many markets still underserved |
 | **Shopping** | 1 | 🟢 High | Only one app. E-commerce + stablecoins is open |
 | **Health / fitness** | 1 | 🟢 High | Only Squadletics. Large green field |
 | **News / media** | 1 | 🟢 High | Only Briefing. Untapped |
-| **Games** | 11 | 🟡 Medium | Competitive, but novel mechanics (skill-based, local IP, cultural context) can still win |
-| **Rewards / earn** | 10 | 🔴 Saturated | Highest competition. Only enter with a structurally different earning mechanic |
+| **Games** | 11 | 🟢 High | Easiest to build and launch; novel mechanics (skill-based, local IP, cultural context) differentiate |
+| **Rewards / earn** | 10 | 🟢 High | High interest from Celo; differentiated earning mechanics have strong potential |
 | **Utility** | 8 | 🟡 Medium | Bill pay dominated by Nigeria-focused apps. Other markets open |
-| **Sports** | 4 | 🟡 Medium | Africa-focused. LATAM sports app gap exists |
+| **Sports** | 4 | 🟡 Medium | Africa-focused. Opportunities in other markets |
 
 ---
 
-## 5. Geo Priority Map
+## 5. Things to Fix Before Submitting
 
-| Region | Countries | MiniPay penetration | Catalog coverage | Best categories to target |
-|--------|-----------|---------------------|-----------------|--------------------------|
-| **West Africa** | NG, GH, SL, CI | 🔴 High — most apps already here | Mostly covered | New mechanics in games, health, news |
-| **East Africa** | KE, UG, TZ, RW | 🟡 Medium | Partially covered | Finance, savings, sports |
-| **LATAM — Brazil** | BR | 🟢 Low | Almost nothing | Prediction, finance, social, shopping |
-| **LATAM — Andean** | CO, AR, PE, CL | 🟢 Low | Almost nothing | Prediction, finance, remittance |
-| **Southeast Asia** | PH, ID | 🟡 Medium | Partial | Remittance, micro-lending |
-| **Southern Africa** | ZA, MW, ZM | 🟢 Low | Almost nothing | Finance, savings, informal commerce |
+These are technical constraints that need to be addressed before your app can function correctly in MiniPay. All of them are fixable — address them during development.
 
-> **LATAM is the single biggest opportunity right now.** High MiniPay user base, almost no apps targeting the region, and the main prediction-market competitor is geo-blocked in Brazil and Argentina.
-
----
-
-## 6. Automatic Disqualifiers
-
-These are hard technical constraints. They are **not fixable with UX changes** — they require architectural decisions before building.
-
-| Disqualifier | Why it blocks you |
+| Item | What to do |
 |---|---|
-| App requires `personal_sign` | MiniPay does not support this method. Any flow that needs off-chain signatures (login, permit, typed auth) will silently fail or error. |
-| App requires `eth_signTypedData` | Same as above — not supported by the MiniPay wallet. |
-| App displays CELO balance or requires CELO payment | MiniPay hides CELO from users entirely. Displaying it breaks the UX contract and will get your app rejected from Discovery. |
-| App only works with EIP-1559 transaction fields | MiniPay uses legacy transactions only. Do not set `maxFeePerGas` or `maxPriorityFeePerGas`. |
-| App can only be tested in an emulator | MiniPay requires a physical device running Android or iOS. If your team cannot test on-device, do not submit yet. |
-| Bundle size > 2 MB or heavy images | Low-bandwidth users will abandon. Use SVG/WebP, lazy-load aggressively, and keep your initial JS bundle small. |
+| App uses `personal_sign` | Replace with wallet-address-only identity or ODIS phone resolution. See `odis-socialconnect.md`. |
+| App uses `eth_signTypedData` | Replace with a flow that only requires `eth_sendTransaction`. |
+| App displays CELO balance or requires CELO payment | Remove CELO from your UI entirely. MiniPay handles gas automatically — users never see it. |
+| App sets EIP-1559 transaction fields | Remove `maxFeePerGas` / `maxPriorityFeePerGas`. Use legacy transaction format. |
+| Bundle size > 2 MB or heavy images | Use SVG/WebP, lazy-load aggressively, and keep your initial JS bundle small. |
 
 ---
 
-## 7. Pre-fit Checklist (run before scoring)
+## 6. Pre-fit Checklist (run before scoring)
 
-Before applying the scorecard, answer these questions. A single "No" on items 1–4 is an immediate Tier 4:
+Before applying the scorecard, answer these questions. A single "No" on items 1–3 is an immediate Tier 4:
 
-- [ ] Can the entire core user flow run inside MiniPay's WebView without external app switching?
-- [ ] Does your app work without `personal_sign` or `eth_signTypedData`?
+- [ ] Can the entire core user flow run inside MiniPay's WebView?
 - [ ] Can you build the UI without showing CELO or raw `0x…` addresses?
-- [ ] Is your app testable on a physical device via ngrok?
 - [ ] Can a non-crypto user understand what the app does from the first screen?
 
 ---
 
-## 8. Example Score — Reference
+## 7. Example Score — Reference
 
 The table below shows a worked example for orientation. Replace with your own app's values.
 
 | Dimension | Score | Rationale |
 |-----------|-------|-----------|
-| A. Stablecoin-native | 2 | All payments and rewards denominated in USDm or USDT |
-| B. No-crypto UX | 2 | "Network fee" not "gas"; no addresses shown; no crypto jargon in UI copy |
-| C. Short-session | 2 | Core action (3 taps): choose → confirm → done |
-| D. Local market fit | 2 | Targets Brazil specifically; fills a gap left by a geo-blocked competitor |
-| E. No-sign-in | 2 | Wallet address = identity; no `personal_sign` anywhere |
-| F. Category gap | 2 | Category has zero Celo-native apps; main competitor geo-blocked |
-| **Total** | **12 / 12** | **🟢 Tier 1 — Build now** |
+| A. Stablecoin-native | 2 | All payments and rewards denominated in USDm, USDT, or USDC |
+| B. Short-session | 2 | Core action (3 taps): choose → confirm → done |
+| C. Local market fit | 2 | Directly solves a documented pain point in a specific primary market |
+| D. No-sign-in | 2 | Wallet address = identity; no `personal_sign` anywhere |
+| E. Category gap | 2 | Category has zero or one Celo-native apps |
+| **Total** | **10 / 10** | **🟢 Tier 1 — Build now** |
 
 ---
 

--- a/skills/celopedia-skill/references/minipay-app-fit.md
+++ b/skills/celopedia-skill/references/minipay-app-fit.md
@@ -72,7 +72,7 @@ Does the core value of your app involve sending, receiving, saving, or earning U
 | **1** | Stablecoins are present but secondary to the main experience |
 | **0** | The app does not involve stablecoin transactions at all |
 
-> **Note:** Network fees are handled automatically by MiniPay via CIP-64 fee abstraction — users never see gas. CELO should not be prominent in your UI. See `builder-guide.md` → *Allowed Fee Currencies (Mainnet)*.
+> **Note:** Network fees are handled automatically by MiniPay via CIP-64 fee abstraction — users can see the fee by tapping Info on the transaction approval screen, but never need to manage it manually. CELO should not be prominent in your UI. See `builder-guide.md` → *Allowed Fee Currencies (Mainnet)*.
 
 ---
 
@@ -110,6 +110,8 @@ Does your app address a need that is acute in at least one of MiniPay's primary 
 | 🇿🇦 South Africa | Township commerce, peer payments, informal savings groups (stokvels) |
 
 > **When filling this dimension:** name the specific country, the pain point, and why your app addresses it better than what already exists in that market.
+>
+> ⚠️ **Licensing reminder:** financial use cases in these markets (payments, savings, lending, FX) require proper local licensing. These categories should not be pursued without compliance and domain expertise — they are not yet fully covered by MiniPay's offer.
 
 ---
 
@@ -167,9 +169,9 @@ Current catalog density from `minipay-live-apps.md` (snapshot — verify before 
 | **Social** | 0 | 🟢 High | No social app listed — but requires network effects, plan for user acquisition from day one |
 | **Health / fitness** | 1 | 🟢 High | Only Squadletics. Large green field |
 | **News / media** | 1 | 🟢 High | Only Briefing. Untapped |
-| **Shopping** | 1 | 🟢 High | E-commerce + stablecoins is open — works best if you already have merchant or user relationships |
-| **Utility** | 8 | 🟡 Medium | Bill pay dominated by Nigeria-focused apps. Other markets open |
-| **Sports** | 4 | 🟡 Medium | Africa-focused. Opportunities in other markets |
+| **Shopping** | 1 | 🟢 High | E-commerce + stablecoins is open — **only if you already have users/traction** |
+| **Utility** | 8 | 🟡 Medium | Bill pay led by Bitgifty and Fonbank (Nigeria-focused). Check which markets they do not cover — that gap is your opportunity |
+| **Sports** | 4 | 🟢 High | Africa-focused. Opportunities in other markets |
 | **Finance — savings/FX** | 7 | 🟠 Established builders only | Many markets underserved, but this space suits teams with existing users and relevant domain background |
 | **Finance — credit/lending** | 0 | 🔴 Requires licensing | Massive market need, but requires financial licensing in each market. Not recommended without legal compliance and domain expertise |
 

--- a/skills/celopedia-skill/references/minipay-app-fit.md
+++ b/skills/celopedia-skill/references/minipay-app-fit.md
@@ -11,6 +11,36 @@
 
 ---
 
+## 0. Understand Your Builder Profile First
+
+Before scoring your idea, answer these questions honestly. Your profile changes what you should build.
+
+**Q1 — How mature is your app?**
+- I have an idea / prototype → **First-time or early builder**
+- I have live users and traction → **Established builder**
+
+**Q2 — Do you have a background in the domain you're building in?**
+- Yes (e.g. fintech, trading, lending) → **Domain expert**
+- No → **Domain generalist**
+
+**Q3 — Does your app involve B2B relationships (partnerships, white-label, enterprise)?**
+- Yes → You need to show existing traction and contracts. Without them, MiniPay is not the right channel yet.
+- No → Continue to scorecard.
+
+**What this means for your recommendations:**
+
+| Profile | Best path |
+|---------|-----------|
+| First-time founder, no traction | Start with **x2earn games** or **pay-as-you-go AI tools** — low regulatory risk, fastest to ship, high demand |
+| Domain expert in fintech / tradfi, existing users | Financial apps (savings, credit, FX) are viable — but require proper licensing in each market you serve |
+| Second-time founder with tradfi background | More options open, including credit/lending — still requires compliance |
+| B2B app, no traction yet | Not a good MiniPay fit right now. Come back when you have live users |
+| B2B app, proven traction | Strong fit — MiniPay gives you direct reach to 14M+ wallets |
+
+> ⚠️ **Financial apps (credit, lending, savings, FX) require licensing in most MiniPay primary markets.** Building without proper compliance puts your users at risk and your app at risk of removal. If you are not established in the domain, default to games or AI pay-as-you-go instead.
+
+---
+
 ## 1. Who Is the MiniPay User?
 
 Before scoring your idea, know the person on the other end of the screen.
@@ -21,11 +51,11 @@ Before scoring your idea, know the person on the other end of the screen.
 | **Device** | Budget Android (most common), basic iOS. Expect small screens, low RAM |
 | **Connectivity** | Intermittent, low bandwidth. 2G/3G is common in primary markets |
 | **Financial profile** | Unbanked or underbanked. Stablecoins serve as the primary savings and payment tool |
-| **Stablecoins available** | USDm, USDC, USDT only. CELO is hidden from users and handled automatically |
+| **Stablecoins available** | USDm, USDC, USDT. Network fees are handled automatically |
 | **Crypto literacy** | Non-crypto-native. Terms like "gas", "onramp", "wallet address", and "blockchain" are UX failures |
 | **Session length** | Short. Single-handed use on mobile, often in noisy or low-attention environments |
 
-**The core implication:** Apps that solve real-money problems (paying bills, earning income, sending money, accessing credit, saving) for non-crypto users win in MiniPay. Apps that require crypto knowledge, long forms, or heavy UI lose.
+**The core implication:** Apps that solve real everyday problems (paying for things, earning income, sending money, accessing services) for non-crypto users win in MiniPay. Apps that require crypto knowledge, long forms, or heavy UI lose.
 
 ---
 
@@ -42,7 +72,7 @@ Does the core value of your app involve sending, receiving, saving, or earning U
 | **1** | Stablecoins are present but secondary to the main experience |
 | **0** | The app does not involve stablecoin transactions at all |
 
-> **Note:** The CELO token must never appear in your UI. MiniPay handles network fees automatically via CIP-64 fee abstraction — see `builder-guide.md` → *Allowed Fee Currencies (Mainnet)*.
+> **Note:** Network fees are handled automatically by MiniPay via CIP-64 fee abstraction — users never see gas. CELO should not be prominent in your UI. See `builder-guide.md` → *Allowed Fee Currencies (Mainnet)*.
 
 ---
 
@@ -68,31 +98,34 @@ Does your app address a need that is acute in at least one of MiniPay's primary 
 | **1** | Useful broadly but not specifically designed for Global South or emerging market users |
 | **0** | Designed primarily for users who already have banking infrastructure |
 
-**Example pain points by market:**
+**Example everyday pain points by market:**
 
 | Country | Acute need |
 |---------|-----------|
-| 🇳🇬 Nigeria | Bill payment, airtime top-up, USD savings against naira inflation |
-| 🇰🇪 Kenya | Micro-savings, remittance corridors, small business payments |
-| 🇧🇷 Brazil | Credit access, PIX-equivalent instant payments, inflation hedging |
-| 🇨🇴 Colombia | Cross-border payments, gig worker payouts, USD savings |
-| 🇵🇭 Philippines | OFW remittances, informal lending, digital tipping |
-| 🇿🇦 South Africa | Informal savings groups (stokvels), township commerce |
+| 🇳🇬 Nigeria | Airtime top-up, bill payment, peer money transfer, earning in USD |
+| 🇰🇪 Kenya | Micro-savings, small business payments, mobile-first commerce |
+| 🇧🇷 Brazil | Fast peer payments, earning opportunities, everyday commerce |
+| 🇨🇴 Colombia | Gig worker payouts, peer-to-peer transfers, everyday services |
+| 🇵🇭 Philippines | Remittances, digital tipping, mobile-first earning |
+| 🇿🇦 South Africa | Township commerce, peer payments, informal savings groups (stokvels) |
 
 > **When filling this dimension:** name the specific country, the pain point, and why your app addresses it better than what already exists in that market.
 
 ---
 
-### D. No-sign-in possible
+### D. Works without `personal_sign`
 MiniPay does not support `personal_sign` or `eth_signTypedData`. Can your app work without them?
 
 | Score | What it means |
 |-------|---------------|
-| **2** | Wallet address alone is sufficient identity — no off-chain auth required |
-| **1** | Needs phone-number → address resolution via ODIS / FederatedAttestations (supported, but adds setup complexity — see `odis-socialconnect.md`) |
+| **2** | Wallet address is sufficient for the core flow — no off-chain signature required |
 | **0** | Requires `personal_sign` or `eth_signTypedData` — **this is a hard technical block; the app cannot function in MiniPay** |
 
+> **Note:** Apps can still collect user data (email addresses, phone numbers, profile info) through regular forms — that is fully supported. This dimension is only about cryptographic signing methods.
+>
 > **Auto-connect is mandatory inside MiniPay.** Never show a "Connect Wallet" button when `window.ethereum.isMiniPay === true`. See `minipay-guide.md` → *Wallet Connection*.
+>
+> Need phone-number → wallet address resolution? ODIS / FederatedAttestations is supported and recommended — see `odis-socialconnect.md`. This adds setup complexity but does not block your score.
 
 ---
 
@@ -111,12 +144,14 @@ Is your category underserved in the MiniPay Discovery catalog right now?
 
 ## 3. Priority Tiers
 
+Use your total score to understand what to do next.
+
 | Total Score | Priority | What to do |
 |-------------|----------|------------|
-| **8–10** | 🟢 **Tier 1 — Build now** | Strong product-channel fit. Prioritise MiniPay Discovery as your primary distribution channel. After building, get a Celo team review before submitting. |
-| **5–7** | 🟡 **Tier 2 — Build with caveats** | Good fit with specific gaps. Identify your lowest-scoring dimension and address it before submission. |
-| **3–4** | 🟠 **Tier 3 — Validate first** | Partial fit. Run an ngrok test with real users in your target market before committing. Consider entering Proof of Ship to get feedback from the Celo community. |
-| **0–2** | 🔴 **Tier 4 — Wrong channel** | Structural mismatch with MiniPay constraints. Pivot the product concept or choose a different distribution channel. Proof of Ship is a good environment for this pivot. |
+| **8–10** | 🟢 **Tier 1 — Build now** | Strong fit. MiniPay Discovery should be your primary distribution target. Get a Celo team review before submitting. |
+| **5–7** | 🟡 **Tier 2 — Build, fix the gaps** | Good fit but one or two dimensions are weak. Find your lowest score, fix that specific gap, then re-evaluate. |
+| **3–4** | 🟠 **Tier 3 — Validate before committing** | Partial fit. Test with real users via ngrok before building further. Consider Proof of Ship to get community feedback first. |
+| **0–2** | 🔴 **Tier 4 — Wrong channel for now** | Structural mismatch with MiniPay. Pivot the concept or choose a different channel. Proof of Ship is a good place to explore alternatives. |
 
 ---
 
@@ -126,16 +161,17 @@ Current catalog density from `minipay-live-apps.md` (snapshot — verify before 
 
 | Category | Apps live | Opportunity | Notes |
 |----------|-----------|-------------|-------|
-| **Social** | 0 | 🟢 High | No social app listed. First mover in a 14M-wallet network |
-| **Finance — credit/lending** | 0 | 🟢 High | No credit app. Massive need in all primary markets |
-| **Finance — savings/FX** | 7 | 🟢 High | Many markets still underserved |
-| **Shopping** | 1 | 🟢 High | Only one app. E-commerce + stablecoins is open |
+| **Games** | 11 | 🟢 High | Easiest to build and launch; strong Celo interest; novel mechanics (skill-based, local IP, cultural context) differentiate |
+| **Rewards / earn** | 10 | 🟢 High | High interest from Celo; differentiated earning mechanics have strong potential |
+| **Pay AI as you go** | 0 | 🟢 High | No apps yet. Pay-per-use AI tools with stablecoin micropayments are a strong fit for MiniPay's UX model |
+| **Social** | 0 | 🟢 High | No social app listed — but requires network effects, plan for user acquisition from day one |
 | **Health / fitness** | 1 | 🟢 High | Only Squadletics. Large green field |
 | **News / media** | 1 | 🟢 High | Only Briefing. Untapped |
-| **Games** | 11 | 🟢 High | Easiest to build and launch; novel mechanics (skill-based, local IP, cultural context) differentiate |
-| **Rewards / earn** | 10 | 🟢 High | High interest from Celo; differentiated earning mechanics have strong potential |
+| **Shopping** | 1 | 🟢 High | E-commerce + stablecoins is open — works best if you already have merchant or user relationships |
 | **Utility** | 8 | 🟡 Medium | Bill pay dominated by Nigeria-focused apps. Other markets open |
 | **Sports** | 4 | 🟡 Medium | Africa-focused. Opportunities in other markets |
+| **Finance — savings/FX** | 7 | 🟠 Established builders only | Many markets underserved, but this space suits teams with existing users and relevant domain background |
+| **Finance — credit/lending** | 0 | 🔴 Requires licensing | Massive market need, but requires financial licensing in each market. Not recommended without legal compliance and domain expertise |
 
 ---
 
@@ -172,7 +208,7 @@ The table below shows a worked example for orientation. Replace with your own ap
 | A. Stablecoin-native | 2 | All payments and rewards denominated in USDm, USDT, or USDC |
 | B. Short-session | 2 | Core action (3 taps): choose → confirm → done |
 | C. Local market fit | 2 | Directly solves a documented pain point in a specific primary market |
-| D. No-sign-in | 2 | Wallet address = identity; no `personal_sign` anywhere |
+| D. No `personal_sign` | 2 | Wallet address = identity; no `personal_sign` anywhere |
 | E. Category gap | 2 | Category has zero or one Celo-native apps |
 | **Total** | **10 / 10** | **🟢 Tier 1 — Build now** |
 

--- a/skills/celopedia-skill/references/minipay-docs-map.md
+++ b/skills/celopedia-skill/references/minipay-docs-map.md
@@ -1,7 +1,9 @@
 # MiniPay Documentation Map
 
-> Source: https://docs.minipay.xyz/
-> Last updated: 2026-05-18
+> **Single source of truth:** https://docs.minipay.xyz/
+> This file is the canonical index of all MiniPay developer documentation pages.
+> All other `minipay-*.md` skill files defer to URLs listed here for authoritative content.
+> Last updated: 2026-05-22
 
 Use this to find the right page in MiniPay's developer docs for any topic. Links go directly to `docs.minipay.xyz`.
 

--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -1,7 +1,6 @@
 # MiniPay Development Guide
 
-> Sources:
-> - MiniPay docs (canonical): https://docs.minipay.xyz/
+> **Single source of truth:** https://docs.minipay.xyz/ — all implementation details in this file are derived from and cross-checked against the official MiniPay developer docs.
 > - docs.celo.org mirror: https://docs.celo.org/build-on-celo/build-on-minipay/*
 >
 > For the full page-by-page index of `docs.minipay.xyz`, see `minipay-docs-map.md`.
@@ -289,6 +288,164 @@ MiniPay requires that apps identify users by **phone number**, not `0x…` hex a
 3. A truncated `0x123…abc` only as a secondary hint — never as the primary identifier.
 
 This is part of MiniPay's submission requirements — see `minipay-requirements.md` §1.
+
+---
+
+## Custom Methods (MiniPay-native RPC)
+
+> Canonical docs: https://docs.minipay.xyz/technical-references/custom-methods/custom-methods.html
+
+MiniPay exposes three custom JSON-RPC methods via `window.ethereum`. They require a Viem custom client built from a typed schema.
+
+### Setup — `useMiniPayClient` hook
+
+```typescript
+import { createWalletClient, custom } from "viem";
+import { celo } from "viem/chains";
+
+// Define the custom RPC schema once, import the hook wherever you need it
+export function useMiniPayClient() {
+  if (typeof window === "undefined" || !window.ethereum) return null;
+  return createWalletClient({
+    chain: celo,
+    transport: custom(window.ethereum),
+  });
+}
+```
+
+---
+
+### `minipay_getExchangeRate` — real-time FX rate
+
+> Docs: https://docs.minipay.xyz/technical-references/custom-methods/get-exchange-rate.html
+
+```typescript
+import { useState, useCallback } from "react";
+import { useMiniPayClient } from "./useMiniPayClient";
+
+export function useGetExchangeRate() {
+  const client = useMiniPayClient();
+  const [rate, setRate] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const getExchangeRate = useCallback(
+    async ({ from, to }: { from: string; to: string }) => {
+      if (!client) return;
+      setIsPending(true);
+      setError(null);
+      try {
+        const result = await client.request({
+          method: "minipay_getExchangeRate" as any,
+          params: [{ from, to }],
+        });
+        setRate(result as string);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [client],
+  );
+
+  return { getExchangeRate, rate, isPending, error };
+}
+
+// Usage — get USDT → NGN rate:
+// const { getExchangeRate, rate } = useGetExchangeRate();
+// await getExchangeRate({ from: "USDT", to: "NGN" });
+```
+
+---
+
+### `minipay_scanQrCode` — native QR scanner
+
+> Docs: https://docs.minipay.xyz/technical-references/custom-methods/scan-qr-code.html
+
+```typescript
+import { useState, useCallback } from "react";
+import { useMiniPayClient } from "./useMiniPayClient";
+
+export function useScanQrCode() {
+  const client = useMiniPayClient();
+  const [scannedValue, setScannedValue] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const scanQrCode = useCallback(async () => {
+    if (!client) return;
+    setIsPending(true);
+    setError(null);
+    try {
+      const result = await client.request({
+        method: "minipay_scanQrCode" as any,
+        params: [],
+      });
+      setScannedValue(result as string);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsPending(false);
+    }
+  }, [client]);
+
+  return { scanQrCode, scannedValue, isPending, error };
+}
+
+// Usage:
+// const { scanQrCode, scannedValue } = useScanQrCode();
+// <button onClick={scanQrCode}>Scan QR</button>
+```
+
+---
+
+### `minipay_requestContact` — native contact picker
+
+> Docs: https://docs.minipay.xyz/technical-references/custom-methods/request-contact.html
+
+Returns `{ name: string; address: string }` — the contact's name and their MiniPay wallet address.
+
+```typescript
+import { useState, useCallback } from "react";
+import { useMiniPayClient } from "./useMiniPayClient";
+
+interface MiniPayContact {
+  name: string;
+  address: string;
+}
+
+export function useRequestContact() {
+  const client = useMiniPayClient();
+  const [contact, setContact] = useState<MiniPayContact | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const requestContact = useCallback(async () => {
+    if (!client) return;
+    setIsPending(true);
+    setError(null);
+    try {
+      const result = await client.request({
+        method: "minipay_requestContact" as any,
+        params: [],
+      });
+      setContact(result as MiniPayContact);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsPending(false);
+    }
+  }, [client]);
+
+  return { requestContact, contact, isPending, error };
+}
+
+// Usage — pick a contact and pre-fill the recipient address:
+// const { requestContact, contact } = useRequestContact();
+// contact?.address → pre-fill send form
+// contact?.name   → display "Send to João"
+```
 
 ---
 

--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -5,7 +5,9 @@
 >
 > For the full page-by-page index of `docs.minipay.xyz`, see `minipay-docs-map.md`.
 
-MiniPay is a non-custodial stablecoin wallet integrated into Opera Mini and available as a standalone app on Android and iOS. It's the fastest growing wallet in the Global South with 16M+ activations, 470M+ stablecoin transactions, 15M+ monthly Mini App opens, available in 66+ countries.
+MiniPay is a non-custodial stablecoin wallet integrated into Opera Mini and available as a standalone app on Android and iOS. It's the fastest growing wallet in the Global South with 16M+ total wallet activations, 470M+ transactions processed, 400M+ Mini App transactions to date, 50+ Mini Apps live, available in 66+ countries.
+
+> Stats sourced from the official MiniPay Q1 2026 report: https://forum.celo.org/t/minipay-update-q1-2026/13273
 
 > Wallet counts are updated by the MiniPay team via the MiniPay site and Celo blog. If a precise current number is needed, prefer fetching from those sources over the number above.
 

--- a/skills/celopedia-skill/references/minipay-requirements.md
+++ b/skills/celopedia-skill/references/minipay-requirements.md
@@ -1,8 +1,7 @@
 # MiniPay Submission Requirements
 
-> Sources:
-> - Opera MiniPay "Build for MiniPay: Developer Requirements" (official PDF)
-> - MiniPay docs: https://docs.minipay.xyz/getting-started/submit-your-miniapp.html
+> **Single source of truth:** https://docs.minipay.xyz/ — specifically https://docs.minipay.xyz/getting-started/submit-your-miniapp.html
+> - Additional source: Opera MiniPay "Build for MiniPay: Developer Requirements" (official PDF)
 >
 > Last updated: 2026-05-18.
 

--- a/skills/celopedia-skill/references/sdk-reference.md
+++ b/skills/celopedia-skill/references/sdk-reference.md
@@ -239,3 +239,90 @@ Quick prototype?
   └── Yes → Thirdweb (prebuilt UI + dashboard)
   └── No → Viem + Wagmi for full control
 ```
+
+---
+
+## Building for MiniPay? Read This First
+
+MiniPay is Celo's embedded stablecoin wallet with 14M+ users across 60+ countries. If you are building a Mini App for MiniPay, the SDK patterns above apply — but with **important constraints and required patterns** that differ from a standard Celo dApp.
+
+### SDK choice for MiniPay
+
+| Requirement | Recommendation |
+|---|---|
+| Wallet connection | **Viem with `custom(window.ethereum)`** or **Wagmi with `injected()` connector** only. Do not use RainbowKit in MiniPay — it renders a multi-wallet selection modal that is incompatible with MiniPay's injected wallet model. |
+| Transactions | **Viem** — required for `feeCurrency` (CIP-64 fee abstraction). All transactions must pay network fees in a stablecoin, never in CELO. |
+| React hooks | **Wagmi** works well — use `injected()` connector, not `metaMask()` or `walletConnect()`. |
+
+### MiniPay detection and zero-click connect (required)
+
+Inside MiniPay, the wallet is pre-injected. **Never show a "Connect Wallet" button.** Detect MiniPay and connect automatically on mount:
+
+```typescript
+import { useEffect } from "react";
+import { useConnect, useAccount } from "wagmi";
+import { injected } from "wagmi/connectors";
+
+function isMiniPay(): boolean {
+  return typeof window !== "undefined" &&
+    (window as { ethereum?: { isMiniPay?: boolean } }).ethereum?.isMiniPay === true;
+}
+
+// In your root component or layout:
+export function AutoConnect() {
+  const { connect } = useConnect();
+  const { isConnected } = useAccount();
+
+  useEffect(() => {
+    if (isMiniPay() && !isConnected) {
+      connect({ connector: injected() });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}
+```
+
+Then in your UI, hide wallet-related buttons when inside MiniPay:
+
+```tsx
+{!isMiniPay() && <ConnectWalletButton />}
+```
+
+### Fee abstraction is mandatory in MiniPay
+
+MiniPay hides CELO from users entirely. Every write transaction must include `feeCurrency` so the network fee is paid in a stablecoin automatically:
+
+```typescript
+// Pay network fee in USDm — user never needs to hold CELO
+await walletClient.writeContract({
+  address: CONTRACT_ADDRESS,
+  abi: myAbi,
+  functionName: "myFunction",
+  args: [arg1, arg2],
+  feeCurrency: "0x765DE816845861e75A25fCA122bb6898B8B1282a", // USDm
+});
+```
+
+For USDC and USDT, use the **adapter address** (not the token address) in `feeCurrency` — see `builder-guide.md` → *Allowed Fee Currencies (Mainnet)* for the full table.
+
+### MiniPay constraints summary
+
+| Constraint | Detail |
+|---|---|
+| No `personal_sign` | MiniPay does not support `personal_sign` or `eth_signTypedData`. Design auth around wallet address only. |
+| Legacy transactions only | Do not set `maxFeePerGas` or `maxPriorityFeePerGas`. Use `feeCurrency` instead. |
+| No CELO in UI | Never display CELO balances or require CELO payments. Show USDm / USDT / USDC only. |
+| Physical device required | MiniPay does not work in browser emulators. Test on a real Android or iOS device via ngrok. |
+| 360 × 640 minimum | Design and test at this viewport. Use Chrome DevTools device mode before submission. |
+
+### Full MiniPay documentation
+
+For the complete integration guide, code templates, phone number resolution via ODIS, deeplinks, ngrok setup, and the official submission checklist:
+
+- `minipay-guide.md` — detection, auto-connect, stablecoin transfers, fee abstraction, deeplinks
+- `minipay-templates.md` — copy-paste code for 6 common Mini App patterns
+- `minipay-scaffold-from-scratch.md` — minimal Next.js + viem setup without Celo Composer
+- `minipay-requirements.md` — official submission checklist (PageSpeed, ToS/Privacy, copy rules, 24h SLA)
+- `minipay-app-fit.md` — scorecard to evaluate whether your idea is a good fit for MiniPay before building


### PR DESCRIPTION
## Summary

This PR addresses gaps identified in a full audit of the celopedia-skill MiniPay references. The audit evaluated five skill areas and found that while the technical integration content (detection, auto-connect, fee abstraction) is thorough, founders had no structured way to evaluate product-channel fit before building, and the SDK reference file gave no indication of MiniPay-specific patterns.

Three files are modified and one new reference file is added.

---

## Changes

### 🆕 `references/minipay-app-fit.md` (new file)

**Problem:** Founders evaluating MiniPay as a distribution channel found no framework for assessing whether their idea was a good fit. The word "fit" did not appear in any of the existing MiniPay reference files.

**What's added:**
- **6-dimension scorecard** (0–2 each, /12 total): stablecoin-native · no-crypto UX · short-session · local market fit · no-sign-in · category gap
- **Priority tiers** (Tier 1–4) with concrete recommendations per score band
- **Category opportunity map** with saturation levels for all 12 Discovery categories, including which are open vs. crowded
- **Geo priority map** documenting LATAM as the single largest underserved region (high MiniPay penetration, almost no apps, main prediction-market competitor geo-blocked in BR/AR)
- **Per-country pain point table** for NG, KE, BR, CO, PH, ZA
- **Hard automatic disqualifiers** — technical constraints that cannot be fixed with UX changes (`personal_sign`, `eth_signTypedData`, CELO in UI, EIP-1559 fields, emulator-only testing)
- **Pre-fit checklist** — 5 binary questions to run before scoring
- **Worked example score** for orientation
- **Full cross-reference links** to all related skill files

---

### `references/sdk-reference.md` — new "Building for MiniPay?" section

**Problem:** A builder reading `sdk-reference.md` to choose their SDK stack for a MiniPay Mini App found zero mention of `isMiniPay`, zero-click connect, or `feeCurrency` requirements. This is the most important constraint of the MiniPay channel and it was completely absent from the SDK reference.

**What's added:**
- SDK choice table: why to use `injected()` over RainbowKit in MiniPay
- Complete `isMiniPay` detection + auto-connect pattern (wagmi)
- `feeCurrency` wiring example for `writeContract`
- MiniPay constraints summary table (no `personal_sign`, legacy tx only, no CELO in UI, physical device required, 360×640 viewport)
- Links to the full MiniPay reference chain

---

### `references/dev-templates.md` — MiniPay callout at top of file

**Problem:** A builder reading only `dev-templates.md` for Celo project setup had no indication that a MiniPay-specific scaffold path exists. The only MiniPay mention was a single scaffold command at the very end of the file.

**What's added:** A callout block at the top of the file pointing to `minipay-scaffold-from-scratch.md`, `minipay-templates.md`, `minipay-app-fit.md`, and the Celo Composer scaffold command — surfaced before the general Foundry/Hardhat setup content.

---

### `SKILL.md` — register `minipay-app-fit.md`

Added the new file to the MiniPay App Builder capability description (§4) and the References list.

---

## Test plan

- [ ] Read `minipay-app-fit.md` end-to-end and score a real project idea — verify the scorecard produces a meaningful Tier rating
- [ ] Read `sdk-reference.md` → "Building for MiniPay?" section — verify a builder can copy the auto-connect pattern and wire `feeCurrency` without reading additional files
- [ ] Read `dev-templates.md` — verify the MiniPay callout is the first thing a builder sees before Foundry setup
- [ ] Confirm all cross-reference links in `minipay-app-fit.md` point to files that exist in the repo
- [ ] Confirm `SKILL.md` references list includes `minipay-app-fit.md`

---

## Out of scope (tracked separately)

- `minipay-live-apps.md` — snapshot only; could link to MiniPay developer portal as live alternative
- Stablecoin content fragmented across 3 files — consolidated reference would help non-MiniPay builders