### PR TITLE
add minipay ios geolocation limitation to constraints list

### DIFF
--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -359,6 +359,7 @@ The ngrok dashboard at `http://localhost:4040` shows all requests for debugging.
 6. **2MB footprint** — Keep Mini App bundle size small
 7. **No CELO in UI** — MiniPay hides CELO from users. Your app must only display and accept USDT / USDC / USDm; fee abstraction handles the network fee in stablecoins automatically
 8. **Submission checklist** — before listing, review `minipay-requirements.md` for the 7-section official checklist (copy rules, 360×640, PageSpeed, ToS / Privacy, 24h SLA)
+9. **No geolocation on iOS** — MiniPay iOS does not bridge `navigator.geolocation` to the OS. `getCurrentPosition` and `watchPosition` hang silently, no callback ever fires, even with location permission granted to MiniPay at the OS level. Same code works fine in MetaMask in-app browser (iOS and Android) and Safari with extension wallets, which points at MiniPay's WKWebView delegate not implementing the geolocation permission handlers. Android behavior untested. Tracked at https://github.com/celo-org/minipay/issues/44. Workaround: detect `isIOS && window.ethereum.isMiniPay` and offer a deep link out to MetaMask (`https://metamask.app.link/dapp/<host>`)
 
 ---
 


### PR DESCRIPTION
ran into this building a location-based mini app and lost about a day debugging before figuring it out. wanted to save the next builder the headache.

tldr: MiniPay iOS WebView doesn't pass geolocation through. getCurrentPosition just hangs, no success no error. happens even when iOS Settings shows location granted to the MiniPay app. tried a bunch of stuff (high vs low accuracy, different timeouts, eager primer before any async to preserve the iOS user-gesture context) and nothing works.

works fine in:
- MetaMask iOS/Android in-app browser
- Safari with a wallet extension

haven't tested MiniPay Android yet so the constraint note is iOS-specific. if anyone confirms Android also fails, happy to update.

filed a feature request to celo-org/minipay#44 with full repro. in the meantime added a one-line note to the constraints list so other builders find it faster.
