### PR TITLE
contract verification: switch celoscan to etherscan v2 unified api

### DIFF
--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -109,17 +109,29 @@ const gasPrice = await publicClient.request({
 
 ## Contract Verification
 
-### Celoscan (Etherscan-family)
+### Celoscan (Etherscan V2 unified API)
+
+Celoscan no longer issues its own API keys. Etherscan unified all family explorers under one V2 API and one key. Use an Etherscan key (free at https://etherscan.io/myapikey) for Celoscan, Basescan, Arbiscan, Optimistic Etherscan, etc.
+
+In `foundry.toml`:
+
+```toml
+[etherscan]
+celo = { key = "${ETHERSCAN_API_KEY}", chain = 42220 }
+alfajores = { key = "${ETHERSCAN_API_KEY}", chain = 44787 }
+```
+
+Then:
 
 ```bash
 # Hardhat
 npx hardhat verify --network celo <CONTRACT_ADDRESS> <CONSTRUCTOR_ARGS>
 
-# Foundry
+# Foundry (no --verifier-url needed; foundry derives it from `chain`)
 forge verify-contract <CONTRACT_ADDRESS> <CONTRACT_NAME> \
-  --chain-id 42220 \
-  --etherscan-api-key <CELOSCAN_API_KEY> \
-  --verifier-url https://api.celoscan.io/api
+  --chain celo \
+  --constructor-args $(cast abi-encode "constructor(...)" ...) \
+  --watch
 ```
 
 ### Blockscout
@@ -130,8 +142,6 @@ forge verify-contract <CONTRACT_ADDRESS> <CONTRACT_NAME> \
   --verifier blockscout \
   --verifier-url https://celo.blockscout.com/api
 ```
-
-Get a Celoscan API key at: https://celoscan.io/myapikey
 
 ---
 


### PR DESCRIPTION
celoscan stopped issuing its own api keys a while back. the etherscan v2 api covers all family explorers (celoscan, basescan, arbiscan, etc) under one key now. the old `--verifier-url https://api.celoscan.io/api` pattern still works but the docs were showing the old way.

the new pattern is cleaner because:

- one key works for verifying on multiple chains (handy when you ship the same contract on celo + base, for example)
- foundry derives the verifier url from the `chain` field in foundry.toml, no `--verifier-url` flag needed
- the api key page is just etherscan.io/myapikey instead of celoscan.io/myapikey

also added a foundry.toml block since this is the cleanest place to put the config (saves passing flags every time).
