### PR TITLE
Add proof-of-ship.md reference file

### DIFF
--- a/skills/celopedia-skill/references/proof-of-ship.md
+++ b/skills/celopedia-skill/references/proof-of-ship.md
@@ -1,0 +1,221 @@
+Proof of Ship
+What is Proof of Ship?
+Proof of Ship is Celo's monthly builder program supporting early-stage projects built on Celo. It was launched in 2025 and has run continuously since. Proof of Ship rewards the development and growth of Mini Apps, paving the way for their potential launch on MiniPay, Opera's self-custodial stablecoin wallet with 16M+ users worldwide.
+
+Proof of Ship is not a hackathon but an incubation-like program. Each month, builders can receive actionable feedback during the weekly Office Hours sessions and get community support through the Telegram group. The top-ranked projects on the leaderboard share a prize pool. In 2026, Proof of Ship rewards are being funded by Celo Public Goods.
+
+Currently, the leaderboard combines Talent Protocol's on-chain activity scoring with a quality review.
+
+Core mission: Proof of Ship is where new Celo projects are born and nurtured. It is the starting point for early-stage builders and solo founders before their products reach the maturity required to access further opportunities, such as MiniPay discovery listing. If you are just getting started, Proof of Ship is the right place.
+Who Is This Program For?
+Proof of Ship is intentionally designed to support builders at every stage, but it is especially valuable for:
+
+Solo founders just starting on Celo
+Early-stage projects moving from idea to MVP to first users
+Builders transitioning from other chains (Base, World, Polygon) who want to bring their product to MiniPay's 16M+ users
+Teams with a working concept that needs iteration before MiniPay listing
+
+Proof of Ship is NOT a fit for:
+
+Projects that want to farm rewards without building a real product
+Enterprise or B2B tools with no consumer-facing utility
+Projects already generating significant revenue and traction elsewhere (they may be ready to skip directly to MiniPay listing)
+
+The natural progression: Proof of Ship > MiniPay Discovery Catalog > Established Mini App. The program is the bridge.
+Solo Founder and Project Maturity Assessment
+Before diving in, assess your current stage honestly. This determines where to focus your energy.
+
+Q1. Are you building solo or with a team? (solo / 2-3 people / larger team)
+Q2. What is your Web3 experience level? (new / 6-18 months / 2+ years)
+Q3. Does your project address a real user need? (idea only / validated with research / tested with users)
+Q4. Do you have domain expertise relevant to your product? (finance, gaming, logistics, etc.)
+Q5. What is the current state of your product? (idea only / smart contract deployed, UI in progress / MVP live but not polished / working app with some real users)
+Reading Your Results
+Stage 1: Idea / Early Builder — new to Web3, solo, no product yet, or strong idea but no domain background.
+
+Proof of Ship is the right place. Focus on:
+
+Building something simple and scoped: a game, a savings widget, a small utility (airtime top-up, group payments)
+Starting with games or X-to-earn mechanics, which have the lowest technical barrier and highest engagement ceiling on MiniPay
+Deploying at least one contract to Celo Mainnet and building a working UI, even if basic
+Using Proof of Ship as a feedback loop, not a payout machine: the program is how you learn what MiniPay users actually need
+
+Red flags to address: No domain background + complex product idea = high risk. A solo founder with no fintech background building a full remittance platform is unlikely to ship something MiniPay-ready in a month. Scope down to the core mechanic first.
+
+Stage 2: Shipping Builder — 6-18 months of experience, MVP deployed, solo or small team.
+
+You are in the Proof of Ship sweet spot. Focus on:
+
+Getting real users on-chain (even 10 wallets paying fees is meaningful)
+Implementing the isMiniPay() detection hook: required for MiniPay listing and a signal you understand the environment
+Building retention mechanics: daily challenges, leaderboards, reward loops, group savings rounds
+Making sure your app loads and works end-to-end on mobile: most quality review failures are apps that look like they work but have dead links and broken flows
+
+Opportunity match: Games with real reward mechanics, P2P payment tools, savings/staking products, gig economy escrow. If building in LATAM: consider PIX-adjacent flows and Spanish/Portuguese localisation. In Asia: gaming culture is dominant, invest in the game loop.
+
+Stage 3: Mature Builder — 2+ years of experience, live product, some real users, domain expertise.
+
+You may be ready for MiniPay listing, not just Proof of Ship rewards. Focus on:
+
+Does your app meet all MiniPay technical requirements?
+Have you completed Stage 1 of the MiniPay intake process at minipay.to/mini-apps?
+Are you tracking retention, not just installs?
+Qualification Requirements
+These are hard gates. Projects that do not meet all of them are ineligible for rewards, regardless of quality score.
+
+Requirement
+Details
+Contract on Celo Mainnet
+At least one smart contract deployed on Mainnet (not just testnet).
+Public GitHub repository
+Must have verifiable commits showing real development activity.
+Live app URL
+Hosted, accessible, and functional.
+Registered on Talent App
+Project enrolled in the active Proof of Ship campaign at talent.app.
+
+
+Note: having the MiniPay hook is no longer a requirement, but a "Nice to Have" counting as a scoring booster. Make sure to include the direct path to the hook in the Data Sources of your Project Page on talent.app to ensure correct tracking.
+
+AI Agents Prize Pool (additional $1,000 USDT, $250 for 4 winners): Project must use agents registered with ERC-8004 and Self Agent ID, and must have a wallet with on-chain transactions.
+
+Reward cap: Projects can participate across multiple months, with a maximum cumulative reward of 2,000 USDT during Season 2 (until June 30th 2026).
+
+Rewards are claimed through MiniPay using the payout Mini App provided by Talent App. If you are among the Top 50 projects but MiniPay is not available in your country, reach out to the Talent team through their support page. The claim deadline is before the rewards distribution for the following month begins.
+How to Participate
+Step 1: Create your builder profile
+
+Go to talent.app and set up your builder profile.
+
+Step 2: Create your project page
+
+Include:
+
+Project name and description
+GitHub repository URL (must be public, with real commits)
+Smart contract address(es) on Celo Mainnet
+Live app URL (hosted, accessible, functional)
+
+Step 3: Submit your project for the current Proof of Ship campaign
+
+On talent.app, submit your project every month, discover your Leaderboard position at the end of the sprint, and, if ranked among the Top 50 projects, prepare your MiniPay wallet to claim your rewards.
+
+Step 4: Keep your data sources updated
+
+The leaderboard pulls live data from GitHub and on-chain activity. Keep committing. Keep shipping. If you are contributing to a monorepo, include the direct path to the MiniPay Hook in your submission for accurate activity tracking.
+
+Step 5: Follow the proposed monthly rhythm
+
+Scope: set your intentions (what you want to build, test, accomplish during the sprint), create a product roadmap, share your plans with trusted peers and mentors to get early feedback before writing a single line of code
+Ship: build in public, deploy, share your progress and learnings, engage the community
+Refine: iterate based on user feedback and analytics, sharpen your UX with product mentors, set up a data dashboard
+Present: define your Go-To-Market and Marketing strategies, search for potential partners and grants, and fine-tune your pitch (nice to have: demo video and a pitch deck)
+
+Step 6: Join the community
+
+Telegram: t.me/proofofship
+Weekly Office Hours: lemonade.social/e/oYjauXnO
+Newsletter: celo-devs.beehiiv.com/subscribe
+X/Twitter: https://x.com/CeloDevs
+What Makes a Strong Submission
+The leaderboard combines Talent Protocol's on-chain activity score and a comprehensive quality review. You cannot game one without the other: strong on-chain activity with a weak product will be penalised, and a polished product with no real users will rank lower than it deserves.
+
+The Celo team review evaluates four dimensions:
+
+1. MiniPay Strategic Fit: Does your product serve MiniPay's users and mission? MiniPay targets mainly emerging market users who need mobile-first, stablecoin-powered tools for payments, savings, earning, and entertainment. The stronger your fit with that mission, the higher this score.
+
+Ask yourself: would someone in Nigeria, Colombia, or Vietnam genuinely use and benefit from this product?
+
+Also, is there already a mini app on MiniPay that is similar to your project? Right now, similar apps will not be prioritized for Discovery Review by the MiniPay team, so if that's your case, we advise you to iterate on the project idea to increase your chances of MiniPay listing.
+
+2. Idea Category Relevance: What you are building matters independently of how well you have built it. Categories with the strongest fit are payments, remittance, savings, on/off ramps, games with real mechanics, gig economy tools, and X-to-earn. Pure NFT marketplaces, developer tools, and enterprise infrastructure are low-fit for MiniPay users. Why should users choose your product instead of your competitors? How will you engage them and incentivize them to come back?
+
+3. Product Quality and Polish: Is your app actually working? Can a real user complete the core flow without getting stuck? Are all the links properly included, and are the main features working? Does your app design feel too "AI-created"? Is the product value proposition clear, and does your app have good copywriting? Quality review failures are most often apps with dead links, broken mobile layouts, or flows that only work on desktop.
+
+4. Traction and On-Chain Activity: Real on-chain fees paid by real users. Even 10 wallets transacting is a strong signal. Zero fees across a full month is a red flag regardless of how good the product looks.
+What to Build
+Build real apps for real people. The focus is on Mini Apps for MiniPay. Think practical, think local, think impact. If it drives real transactions from real users, you are on the right track.
+Highest Fit (Tier 1)
+Games with real reward mechanics and USDm prize pools
+Utility bill payments (airtime, data, electricity, cable TV) in USDm/cUSD — only in countries where those are not yet available
+X-to-earn applications (earn-to-learn, earn-to-play, earn-to-exercise)
+Gig economy escrow and micropayment tools (only if you have strong background and existing users in a web2 app)
+AI-powered consumer tools for emerging market users
+AI agents focused on real-world use cases
+Loyalty and engagement loops
+Strong Fit (Tier 2)
+Sports prediction markets with stablecoin stakes
+Educational platforms with crypto rewards
+Lower Fit
+Peer-to-peer marketplaces for digital or physical goods (needs existing customers / experience / background)
+Freelance and escrow platforms
+Market-Specific Opportunities
+LATAM (Brazil): PIX-adjacent flows, ARS peso hedge tools
+LATAM (Colombia/Argentina): El Dorado/Alfred ramp integrations
+Southeast Asia: gaming-first mechanics
+What to Avoid
+Gambling
+Pure NFT art marketplaces (low fit for MiniPay's user base)
+Infrastructure and developer tools (valuable for Celo but not for Proof of Ship)
+Enterprise/B2B applications if you are a solo founder
+DeFi apps by solo builders without audit coverage or regulatory awareness: for a first project, build a game or an X-to-earn platform instead
+Reward farming apps or engagement bots
+Program History
+Proof of Ship launched in 2025 and has run monthly since Season 1. As of April 2026 (Season 11 / Season 2 of the redesigned program):
+
+Over 174 unique quality projects participated across Seasons 7-10 alone
+Season 2 (April-July 2026) introduced a redesigned sprint rhythm and an updated quality scoring framework
+Past partnership tracks have included category-specific rewards and ecosystem integrations with the broader Celo builder community
+
+Full historical stats are tracked on the Proof of Ship Dune dashboard.
+FAQ
+Do I need a finished product to join?
+
+No. You do not need a finished product to register. Start now, improve as you go, and let your progress do the talking. The leaderboard updates weekly, so there is always time to climb.
+
+Can I submit multiple projects?
+
+Each builder can submit projects under their account. Multiple minimal-effort submissions from the same builder in the same round with no genuine product differentiation are identified as a farming pattern and excluded. Focus on one strong project.
+
+What is the isMiniPay() hook and why does it matter?
+
+isMiniPay() is a detection function that tells your app when it is being loaded inside the MiniPay browser environment. When detected, your app should adapt: hide non-compatible wallet connection flows, use the injected MiniPay provider, and apply mobile-first layout constraints. Without this hook, the app cannot be listed in MiniPay's discovery catalog.
+
+What is MiniPay's 2MB bundle limit?
+
+Each Mini App must have a JavaScript bundle under 2MB to load inside MiniPay. Use code splitting, lazy loading, and minimal dependencies. Check your bundle size before submission.
+
+My app is live on Base/World. Can I submit a Celo port?
+
+Yes. Cross-chain products with real users elsewhere are viewed positively: they demonstrate the product has genuine traction. Your Celo deployment must still meet all qualification requirements independently.
+
+How do I get feedback on my project?
+
+Attend weekly Office Hours at lemonade.social/e/oYjauXnO. Post in the Telegram community. After each monthly review, eligible projects receive written feedback with specific recommendations.
+
+How are rewards calculated?
+
+Top 10 projects share 50% of the $5,000 USDT prize pool, distributed proportionally to score. Top 11-50 share the remaining 50%, also distributed proportionally. Top 3 receive priority mentor access (30-min sessions). The monthly winner receives user incentives and badges (this perk can only be awarded once per project during Season 2).
+
+What are my opportunities after Proof of Ship?
+
+The natural next step is MiniPay listing. Projects that meet all technical requirements can apply through the Stage 1 intake form at minipay.to/mini-apps. Beyond that, Talent App builds your on-chain reputation as a public credential that unlocks ecosystem opportunities across grants, partnerships, and further funding programs.
+Key Links
+Resource
+URL
+Program page
+https://celoplatform.notion.site/Proof-of-Ship-17cd5cb803de8060ba10d22a72b549f8
+Submit your project
+https://talent.app/~/earn/celo-proof-of-ship
+Live stats dashboard
+https://dune.com/celo/proof-of-ship-stats
+Telegram community
+https://t.me/proofofship
+Weekly Office Hours
+https://lemonade.social/e/oYjauXnO
+Newsletter
+https://celo-devs.beehiiv.com/subscribe
+X / Twitter
+https://x.com/CeloDevs
+
+


### PR DESCRIPTION
Adds a dedicated Proof of Ship reference file to the Celopedia skill.

- New file: skills/celopedia-skill/references/proof-of-ship.md
- Covers: program overview, qualification requirements, solo founder diagnostic (5-question maturity assessment), what to build (tiered categories), participation steps, quality review dimensions, FAQ
- Updated SKILL.md: added Capability 12 (Proof of Ship) and routing table row

Part of the DevRel team effort to expand Celopedia with PoS + MiniPay skill flags.