### PR TITLE
Fix ERC-8004 agent metadata to current spec (services, type, content-addressing)

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -250,3 +250,10 @@ When a builder has a new idea, guide them through:
 
    Code identifiers and RPC method names (`gasEstimate`, `eth_gasPrice`, `feeCurrency`) are technical and should stay unchanged. See `minipay-requirements.md` §3.
 10. **MiniPay token scope.** Only USDT / USDC / USDm. **Never display or require CELO** in Mini Apps — MiniPay hides it from users and handles fees via fee abstraction.
+11. **ERC-8004 metadata compliance (enforced).** When generating or reviewing agent registration metadata, **flag and correct** these deprecated patterns before the user registers (they trigger validator warnings):
+    - `"type": "Agent"` → use the spec URI `"https://eips.ethereum.org/EIPS/eip-8004#registration-v1"`
+    - `endpoints` array → renamed to `services`
+    - `url` field per entry → renamed to `endpoint` (each service needs `name` + `endpoint`)
+    - `https://` agentURI → prefer content-addressed `ipfs://` (or `data:`) so metadata can't be silently mutated after registration
+
+    See `ai-agents.md` → _Metadata Compliance_ for the compliant example and checklist.

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -53,22 +53,24 @@ Agents register as ERC-721 NFTs with metadata URI. Each agent gets a unique `age
 | `tokenURI(uint256 agentId)` | Get full metadata URI |
 | `ownerOf(uint256 agentId)` | Get agent owner |
 
-**Agent metadata format:**
+**Agent metadata format (spec-compliant):**
 
 ```json
 {
-  "type": "Agent",
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
   "name": "MyAgent",
   "description": "An AI agent that...",
   "image": "ipfs://...",
-  "endpoints": [
-    { "type": "a2a", "url": "https://example.com/.well-known/agent.json" },
-    { "type": "mcp", "url": "https://example.com/mcp" },
-    { "type": "wallet", "address": "0x...", "chainId": 42220 }
+  "services": [
+    { "name": "A2A", "endpoint": "https://example.com/.well-known/agent.json" },
+    { "name": "MCP", "endpoint": "https://example.com/mcp" },
+    { "name": "web", "endpoint": "https://example.com" }
   ],
   "supportedTrust": ["reputation", "validation", "tee"]
 }
 ```
+
+> ⚠️ This format follows the **current** EIP-8004 spec. Older examples (including earlier versions of this file) used `"type": "Agent"`, an `endpoints` array, and a `url` field per entry — all three now trigger validation warnings. See **Metadata Compliance** below before registering.
 
 ### Reputation Registry
 
@@ -109,6 +111,50 @@ const txHash = await client.writeContract({
   args: ["ipfs://QmYourAgentMetadata"],
 });
 ```
+
+### Metadata Compliance (avoid validation warnings)
+
+Registering an agent runs metadata through a validator (e.g. 8004scan). The four most common warnings — and their fixes — all come from following an outdated metadata shape:
+
+| Warning | Cause | Fix |
+|---------|-------|-----|
+| **`type` — invalid value `Agent`** | The `type` field expects the spec's versioned registration identifier, not a freeform label | Set `type` to `"https://eips.ethereum.org/EIPS/eip-8004#registration-v1"` |
+| **`services` — deprecated `endpoints` field** | EIP-8004 renamed `endpoints` → `services` | Rename the array to `services` |
+| **`services` — missing `endpoint` field** | Each service entry now keys its URL on `endpoint`, not `url` | Use `{ "name": "...", "endpoint": "..." }` per entry |
+| **`agentURI` — not content-addressed** | An `https://` metadata URI can be silently mutated after registration; the validator can't detect tampering | Pin metadata to IPFS and register an `ipfs://` URI (the CID *is* the integrity check). `data:` base64 URIs (fully on-chain) are also content-addressed |
+
+**Fully compliant metadata example:**
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "MyAgent",
+  "description": "An AI agent that executes USDT payments on Celo.",
+  "image": "ipfs://bafybeib.../logo.png",
+  "services": [
+    { "name": "A2A", "endpoint": "https://myagent.xyz/.well-known/agent.json", "version": "1.0" },
+    { "name": "MCP", "endpoint": "https://myagent.xyz/api/mcp" },
+    { "name": "web", "endpoint": "https://myagent.xyz" }
+  ],
+  "supportedTrust": ["reputation", "validation"]
+}
+```
+
+**`services` field reference:**
+- `name` (required) — the service type. Common values: `web`, `A2A`, `MCP`, `OASF`, `ENS`, `DID`, `email`.
+- `endpoint` (required) — the service URI or address (replaces the old `url`).
+- `version` (optional, SHOULD) — service version string.
+- `skills` / `domains` (optional) — only for `OASF` services.
+
+**Why content-addressing matters.** With `ipfs://`, the CID is derived from the content, so any change to the metadata produces a different CID — tampering is impossible to hide. With `https://`, the host can swap the metadata after registration and no one can prove it changed (unless you separately commit a hash). For agents whose reputation depends on stable identity, pin to IPFS.
+
+**Compliance checklist before calling `register()`:**
+- [ ] `type` is the `#registration-v1` spec URI, not `"Agent"`
+- [ ] `services` (not `endpoints`), each entry has `name` + `endpoint` (not `url`)
+- [ ] `agentURI` passed to `register()` is `ipfs://` or `data:` (content-addressed), not `https://`
+- [ ] Metadata pinned to a persistent IPFS provider (so the CID stays resolvable)
+
+**Further reading:** EIP-8004 spec (https://eips.ethereum.org/EIPS/eip-8004) · best-practices guide (https://best-practices.8004scan.io).
 
 ---
 


### PR DESCRIPTION
## Summary

The agent metadata example in `ai-agents.md` uses a shape that the **EIP-8004 validator** (e.g. [8004scan](https://best-practices.8004scan.io)) now flags with four warnings. A builder copying the example hits all four immediately during registration:

- `Invalid type field value: Agent`
- `Using deprecated 'endpoints' field. EIP-8004 spec now uses 'services'`
- `Service missing 'endpoint' URL field`
- `agentURI is not content-addressed (metadata can be changed without detection)`

This PR fixes the example **at the source** and adds a dedicated **Metadata Compliance** section plus an enforced SKILL.md rule, so the skill proactively steers builders to the compliant shape instead of generating the deprecated one.

## Deprecated → compliant

| Field | Was (triggers warning) | Now (spec-compliant) |
|-------|------------------------|----------------------|
| `type` | `"Agent"` | `"https://eips.ethereum.org/EIPS/eip-8004#registration-v1"` |
| service array | `"endpoints"` | `"services"` |
| per-entry URL key | `"url"` | `"endpoint"` (each entry: `name` + `endpoint`) |
| `agentURI` scheme | `https://` (mutable) | `ipfs://` or `data:` (content-addressed) |

## Changes

### `references/ai-agents.md`
- Fix the agent metadata example (the root cause of the warnings)
- Add a **Metadata Compliance** subsection:
  - Table mapping each validator warning → its fix
  - A fully compliant metadata example
  - `services` field reference (`name`, `endpoint`, optional `version`, `skills`/`domains` for OASF)
  - Why content-addressing matters (IPFS CID = built-in tamper detection vs. mutable HTTPS)
  - Pre-`register()` compliance checklist

### `SKILL.md`
- Add **Rule 11 — ERC-8004 metadata compliance (enforced)**: the skill now flags `"type": "Agent"`, `endpoints`, per-entry `url`, and `https://` agentURIs when generating or reviewing agent metadata — mirroring how the MiniPay copy rules work.

## Sources

- EIP-8004 spec — https://eips.ethereum.org/EIPS/eip-8004 (the `services` schema, `#registration-v1` type, and URI-scheme guidance are taken directly from the spec)
- best-practices guide — https://best-practices.8004scan.io

## Test plan

- [ ] Generate agent metadata with the skill and confirm it produces `type: ...#registration-v1`, `services`, and `endpoint` (never `Agent`/`endpoints`/`url`)
- [ ] Run the new compliant example through the 8004scan validator — confirm zero metadata warnings
- [ ] Confirm `register()` examples pass an `ipfs://` (not `https://`) agentURI
- [ ] Confirm Rule 11 in SKILL.md triggers a correction when a builder pastes a `"type": "Agent"` blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)