### PR TITLE
Lead with m-suffix Mento naming in prose; strengthen Rule 3

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -82,7 +82,7 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 14M+ users.
 - MiniPay detection (`window.ethereum.isMiniPay`)
 - Auto-connect patterns (no connect button in MiniPay)
 - Stablecoin payments with fee abstraction
-- Phone number → address via **ODIS (PnP) quota**, **OdisPayments** (cUSD/USDm top-up), **FederatedAttestations**, and **MiniPay issuer** (`0x7888612486844Bb9BE598668081c59A9f7367FBc` as trusted issuer)
+- Phone number → address via **ODIS (PnP) quota**, **OdisPayments** (USDm/cUSD top-up), **FederatedAttestations**, and **MiniPay issuer** (`0x7888612486844Bb9BE598668081c59A9f7367FBc` as trusted issuer)
 - Testing with ngrok on physical devices
 - UX best practices for emerging markets
 - Ready-to-use templates: payment flow, bill payment, balance display
@@ -247,7 +247,7 @@ When a builder has a new idea, guide them through:
 
 1. **Never guess contract addresses.** Wrong addresses = lost funds. If not in references, say so.
 2. **Celo is an L2, not an L1.** Migrated March 26, 2025 (block 31,056,500).
-3. **Mento stablecoins rebranded.** cUSD → USDm, cEUR → EURm, cREAL → BRLm. Both names valid.
+3. **Mento stablecoins rebranded — lead with the m-suffix name.** The new canonical naming is `{CURRENCY}m`: cUSD → USDm, cEUR → EURm, cREAL → BRLm. The same pattern extends to the regional stablecoins (`COPm`, `KESm`, `PHPm`, `BRLm`, `NGNm`, `ZARm`, etc.). When generating prose, code, UI copy, or examples, **lead with the m-suffix name**; the c-prefix is the legacy alias and should appear only as a parenthetical lookup aid (e.g. `USDm (cUSD)`) or in historical/factual contexts (past grant announcements, third-party app marketing snapshots, on-chain function names like `payInCUSD`).
 4. **Token decimals matter.** USDm = 18, USDC/USDT = 6. Always verify.
 5. **The Grid has no full-text search.** Only `_contains`/`_ilike` substring matching.
 6. **Filter for EVM.** Exclude non-EVM results unless asked.

--- a/skills/celopedia-skill/references/odis-socialconnect.md
+++ b/skills/celopedia-skill/references/odis-socialconnect.md
@@ -41,8 +41,8 @@ Verified core addresses are in **`contracts.md`**:
 | Role | Contract | Notes |
 |------|----------|--------|
 | Attestation registry | **FederatedAttestations** `0x0aD5b1d0C25ecF6266Dd951403723B2687d6aff2` | Use `kit.contracts.getFederatedAttestations()` with ContractKit |
-| Quota payment | **OdisPayments** `0xAE6B29f31B96e61DdDc792f45fDa4e4F0356D0CB` | Pulls **cUSD / USDm** (StableToken) to credit PnP quota |
-| cUSD / USDm token | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | 18 decimals — see `minipay-guide.md` |
+| Quota payment | **OdisPayments** `0xAE6B29f31B96e61DdDc792f45fDa4e4F0356D0CB` | Pulls **USDm / cUSD** (StableToken) to credit PnP quota |
+| USDm / cUSD token | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | 18 decimals — see `minipay-guide.md` |
 
 ### MiniPay issuer (trusted issuer for lookups)
 
@@ -98,7 +98,7 @@ const authSigner: AuthSigner = {
 ## Quota (mainnet gotcha)
 
 - **`getPnpQuotaStatus(account, authSigner, serviceContext)`** returns `remainingQuota`, `totalQuota`, `performedQueryCount`.
-- **Having cUSD/USDm in the wallet does not automatically grant PnP quota.** If `remainingQuota` is **0**, you typically must pay into **`OdisPayments`**:
+- **Having USDm/cUSD in the wallet does not automatically grant PnP quota.** If `remainingQuota` is **0**, you typically must pay into **`OdisPayments`**:
   1. **`StableToken.increaseAllowance(odisPaymentsAddress, amountWei)`**
   2. **`OdisPayments.payInCUSD(quotaAccount, amountWei)`** — credits **that account’s** PnP quota.
 


### PR DESCRIPTION
## Summary

The skill correctly uses the new `{CURRENCY}m` Mento naming convention in most places — **152 m-suffix vs 28 c-prefix mentions** across SKILL.md and references — and the reference tables already follow the canonical `USDm (cUSD)` format. But four prose mentions still **lead with the deprecated c-prefix**, and Rule 3 only said *"both names valid"* without telling the skill which to prefer in newly-generated content.

This PR strengthens Rule 3 to specify **m-suffix-first** and fixes the four stale prose mentions.

## Audit findings

After auditing every c-prefix occurrence (`cUSD`, `cEUR`, `cREAL`, plus regional `cCOP`, `cKES`, `cPHP`, etc.):

| Where | Status |
|-------|--------|
| Reference tables (`contracts.md`, `network-info.md`, `builder-guide.md`, `defi-protocols.md`, `ecosystem.md`, `minipay-guide.md`, `business-model.md`, `live-data-sources.md`) | ✅ Already `USDm (cUSD)` format — correct |
| **4 prose mentions in `SKILL.md` + `odis-socialconnect.md`** | 🔴 Lead with c-prefix — fixed in this PR |
| `payInCUSD` Solidity function name | ✅ Actual on-chain method — intentionally not touched |
| `30K cUSD` in `grants-funding.md` historical grant announcements | ✅ Factual record of what was originally announced — not touched |
| `Use cUSD to Earn \$MENTO` snapshot in `minipay-live-apps.md` | ✅ Third-party app marketing copy (Mento Labs' own wording) — not touched |

## Changes

### `SKILL.md` — Rule 3 (Mento rebrand) strengthened

**Before:**
> Mento stablecoins rebranded. cUSD → USDm, cEUR → EURm, cREAL → BRLm. Both names valid.

**After:**
> Mento stablecoins rebranded — **lead with the m-suffix name**. The new canonical naming is `{CURRENCY}m`: cUSD → USDm, cEUR → EURm, cREAL → BRLm. The same pattern extends to the regional stablecoins (`COPm`, `KESm`, `PHPm`, `BRLm`, `NGNm`, `ZARm`, etc.). When generating prose, code, UI copy, or examples, **lead with the m-suffix name**; the c-prefix is the legacy alias and should appear only as a parenthetical lookup aid (e.g. `USDm (cUSD)`) or in historical/factual contexts (past grant announcements, third-party app marketing snapshots, on-chain function names like `payInCUSD`).

### `SKILL.md` Capability 4 — line 85
- `OdisPayments` (cUSD/USDm top-up) → `OdisPayments` (USDm/cUSD top-up)

### `references/odis-socialconnect.md` — 3 prose mentions
- Line 44: `Pulls **cUSD / USDm**` → `Pulls **USDm / cUSD**`
- Line 45: `cUSD / USDm token` → `USDm / cUSD token`
- Line 101: `Having cUSD/USDm in the wallet` → `Having USDm/cUSD in the wallet`

## Test plan

- [ ] Ask the skill "what stablecoin should I use for {Argentina/Kenya/Philippines/etc.}?" — verify the response leads with m-suffix names (USDm, KESm, PHPm) and only mentions the c-prefix as a parenthetical
- [ ] Ask the skill to generate ODIS quota top-up code — verify prose uses `USDm/cUSD` ordering (the `payInCUSD` function name stays unchanged since it's a real on-chain method)
- [ ] Confirm reference tables still resolve `cUSD` lookups (they should — `USDm (cUSD)` format preserves the alias)
- [ ] Confirm historical grant amounts in `grants-funding.md` still show `cUSD` (intentional — factual record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)