### PR TITLE
docs(minipay): refresh headline stats to Q1 2026 figures

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.3.0"
+  version: "2.3.1"
 ---
 
 # Celopedia Skill
@@ -22,7 +22,7 @@ Celo is a leading **Ethereum L2** (OP Stack + EigenDA + zkEVM). Purpose-built fo
 - **Chain ID**: 42220 (Mainnet), 11142220 (Sepolia Testnet)
 - **Block time**: ~1 second | **Gas**: ~$0.0005 | **Fee abstraction**: Pay gas with USDC, USDT, USDm
 - **Stablecoins**: 15+ Mento local-currency stablecoins + USDC + USDT
-- **MiniPay**: 14M+ wallets, 300M+ stablecoin transactions, 60+ countries
+- **MiniPay**: 16M+ wallets, 470M+ transactions, 66+ countries
 
 ---
 

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -224,7 +224,7 @@ Wallet docs: https://docs.celo.org/tooling/wallets/index
 
 MiniPay is Celo's flagship stablecoin wallet, built into Opera Mini and also available as a standalone app.
 
-**Stats**: 14M+ wallets, 300M+ stablecoin transactions, 15M+ monthly Mini App opens, 60+ countries
+**Stats**: 16M+ wallets, 470M+ transactions, 15M+ monthly Mini App opens, 66+ countries
 
 ### Known Mini Apps
 


### PR DESCRIPTION
## What
Refresh the MiniPay headline stats to the latest official figures, and bump the skill version per CONTRIBUTING.

## Source
MiniPay Update Q1 2026 — official `opera_minipay` account, Celo Forum, 2026-05-05:
https://forum.celo.org/t/minipay-update-q1-2026/13273
- 16M+ total wallet activations
- 470M+ transactions processed
- 66+ countries
- 50+ Mini Apps live

## Changes
- `SKILL.md` — `## What is Celo?` MiniPay stat line: `14M+/300M+/60+` → `16M+/470M+/66+`; version `2.3.0` → `2.3.1`
- `references/ecosystem.md` — MiniPay stats line: same refresh (left `15M+ monthly Mini App opens`, not in the source)

## Scope / coordination
Kept deliberately narrow to avoid overlap with open PRs:
- `minipay-guide.md` is already refreshed to these numbers in #9 — left untouched.
- The Capability-4 MiniPay block in `SKILL.md` (its `14M+ users` line) is being edited by #9 and #20 — left for those PRs.
- `proof-of-ship.md` already uses 16M+ — untouched.

## Notes
- Dropped the `stablecoin` qualifier before `transactions`: the 470M+ figure is total transactions processed, not labelled stablecoin-specific in the source.
- Version bumped to 2.3.1 per the CONTRIBUTING step for updating outdated info. Drop it if you're versioning centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
