### PR TITLE
docs(celopedia): add Self Agent ID registration reference

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -85,12 +85,13 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 14M+ users.
 Build AI agents that transact on Celo.
 
 - **ERC-8004**: Agent Trust Protocol (identity + reputation registries)
+- **Self Agent ID**: proof-of-human verification for agents (ERC-8004 extension; soulbound NFT bound to a passport ZK proof)
 - **x402**: HTTP-native micropayments with stablecoins
 - **Celo MCP Server**: Query blockchain data from coding assistants
 - **Agent Skills**: Modular skill system for AI coding agents
 - Use cases: FX arbitrage, prediction markets, automated payments
 
-**References**: `ai-agents.md`
+**References**: `ai-agents.md`, `self-agent-id.md`
 
 ### 6. Security & Audit Readiness
 

--- a/skills/celopedia-skill/references/self-agent-id.md
+++ b/skills/celopedia-skill/references/self-agent-id.md
@@ -1,0 +1,61 @@
+# Self Agent ID
+
+> Source of truth: `https://app.ai.self.xyz/api/agent/bootstrap` returns a live OpenAPI spec of the registration-relevant endpoints. Always check it for the current contract / shape.
+
+Self Agent ID is Self Protocol's **proof-of-human extension on top of ERC-8004**. It binds an AI agent's keypair to a real human via a zero-knowledge passport proof and mints a **soulbound ERC-721 NFT on Celo**. This is the Sybil-resistance layer some programs require (e.g. the Onchain Agents hackathon's *Verification* criterion).
+
+| | ERC-8004 Identity Registry | Self Agent ID |
+|---|---|---|
+| What | Mints an agent NFT (open to anyone) | Adds a proof-of-human binding |
+| Trust | None inherent | Soulbound NFT ↔ human nullifier via ZK passport |
+| See | `ai-agents.md`, the `8004` skill | this file |
+
+## Prerequisites
+
+- **Self mobile app** with a scanned identity document. Mainnet (chain `42220`) needs a **real passport**; Celo Sepolia testnet (`11142220`) accepts mock documents in the app.
+- The wallet you want as the agent identity / human owner. To link a Self Agent ID to an ERC-8004 agent, reuse the **same wallet** so the human owner matches.
+
+## Flow
+
+1. **`POST /api/agent/register`** → creates a session, returns `sessionToken`, `qrData`, `deepLink`, and `scanUrl`.
+2. Open the `scanUrl` (QR) or `deepLink`, then **scan your passport in the Self app**. The ZK proof is generated on-device — only a proof + nullifier go on-chain.
+3. **Poll `GET /api/agent/register/status`** until `stage` is `registered`.
+4. (linked / wallet-free modes) **`POST /api/agent/register/export`** to export the server-generated agent private key.
+
+### Registration modes
+
+| Mode | `humanAddress` required? | Agent key |
+|---|---|---|
+| `linked` | yes | server-generated (exportable) |
+| `wallet-free` | no | server-generated (exportable) |
+| `ed25519` | no | bring-your-own Ed25519 (sign a challenge first) |
+| `ed25519-linked` | yes | bring-your-own Ed25519 |
+| `privy` / `smartwallet` | yes | provider-managed |
+
+For `ed25519` modes, first call `POST /api/agent/register/ed25519-challenge` to get the challenge hash to sign.
+
+## ⚠️ Gotchas
+
+- **Status auth:** `GET /api/agent/register/status` requires `Authorization: Bearer <sessionToken>` — passing `token` as a query param returns `400` despite what the OpenAPI advertises.
+- **Session TTL:** registration sessions expire in ~30 min. Poll promptly; expiry returns `410` but does **not** undo an on-chain registration that already completed — verify on-chain (or via a fresh session) rather than re-scanning.
+- **`linked` creates a new agent key** bound to your `humanAddress`; it is *not* your wallet's key. If you need your existing key to be the agent, use an `ed25519` mode.
+
+## Example
+
+```bash
+# 1. Start a session (linked mode, mainnet, your wallet as human owner)
+curl -X POST https://app.ai.self.xyz/api/agent/register \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"linked","network":"mainnet","humanAddress":"0xYourWallet"}'
+# → { "sessionToken": "...", "scanUrl": "https://app.ai.self.xyz/scan/...", "deepLink": "...", ... }
+
+# 2. Open scanUrl / deepLink and scan your passport in the Self app.
+
+# 3. Poll until registered (NOTE the Bearer header)
+curl -H "Authorization: Bearer <sessionToken>" \
+  https://app.ai.self.xyz/api/agent/register/status
+```
+
+## Related
+- `ai-agents.md` — ERC-8004 identity + reputation registries
+- The `8004` skill — registering the ERC-8004 agent NFT with viem


### PR DESCRIPTION
## What

Adds `references/self-agent-id.md` documenting **Self Protocol Agent ID** — the proof-of-human extension on top of ERC-8004 (soulbound NFT bound to a passport ZK proof on Celo), plus a pointer from `SKILL.md`.

## Why

Building an onchain agent for the Onchain Agents hackathon, the **Verification** criterion required a Self Agent ID, but there was no Celopedia reference — I had to reverse-engineer the flow from `app.ai.self.xyz/api/agent/bootstrap`. This fills that gap. Addresses #24.

## Contents
- Registration modes (`linked`, `wallet-free`, `ed25519`(`-linked`), `privy`, `smartwallet`) and which need a `humanAddress`
- The flow: `POST /api/agent/register` → passport scan in the Self app → poll `/api/agent/register/status`
- Gotchas verified in practice: status needs `Authorization: Bearer <sessionToken>` (query-param `token` 400s); sessions expire ~30 min (410, but doesn't undo a completed on-chain registration); `linked` mints a *new* agent key bound to the human address
- Example curl flow

Verified end-to-end on Celo mainnet (registered Self Agent ID #157 alongside ERC-8004 agentId 9221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)