### PR TITLE
feat(skill): v2.4.0 — Agent Visa, Self Agent ID, hackathon, full fee-currency allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Foundry/Hardhat configs for Celo, fee abstraction implementation, SDK selection 
 Deep protocol reference for Uniswap V3/V4, Aave V3, Carbon DeFi, Morpho Blue, Mento stablecoins, stCELO, Velodrome, and Curve on Celo. Includes contract addresses, interaction patterns, and yield strategies.
 
 ### MiniPay App Builder
-Build Mini Apps for MiniPay (14M+ wallets). Wallet detection, auto-connect patterns, stablecoin payments, phone number resolution, testing with ngrok, and ready-to-use code templates. Includes the official submission checklist (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA).
+Build Mini Apps for MiniPay (16M+ wallets). Wallet detection, auto-connect patterns, stablecoin payments, phone number resolution, testing with ngrok, and ready-to-use code templates. Includes the official submission checklist (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA).
 
 ### AI Agent Builder
-ERC-8004 (Agent Trust Protocol), x402 (HTTP micropayments), Celo MCP Server, and the Agent Skills specification. Build AI agents that transact autonomously on Celo.
+ERC-8004 (Agent Trust Protocol), Self Agent ID (proof-of-human), the Celo Agent Visa program, x402 (HTTP micropayments), Celo MCP Server, and the Agent Skills specification. Build onchain agents that transact autonomously on Celo.
 
 ### Security & Audit Readiness
 Celo-specific security patterns (CELO duality, CIP-64 fee abstraction, Aave aToken drift, Mento circuit breakers, post-L2 epoch effects). Chain-agnostic Solidity audits defer to [pashov/skills](https://github.com/pashov/skills).

--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -21,7 +21,7 @@ Celo is a leading **Ethereum L2** (OP Stack + EigenDA + zkEVM). Purpose-built fo
 
 - **Chain ID**: 42220 (Mainnet), 11142220 (Sepolia Testnet)
 - **Block time**: ~1 second | **Gas**: ~$0.0005 | **Fee abstraction**: Pay gas with USDC, USDT, USDm
-- **Stablecoins**: 15+ Mento local-currency stablecoins + USDC + USDT
+- **Stablecoins**: 15+ Mento local-currency stablecoins (USDm, EURm, BRLm, KESm, COPm, GHSm, NGNm, ZARm, GBPm, CADm, AUDm, CHFm, JPYm, XOFm, PHPm) + external USDC, USDT, USAT — see `contracts.md` / `ecosystem.md`
 - **MiniPay**: 16M+ wallets, 470M+ transactions, 66+ countries
 
 ---

--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.3.1"
+  version: "2.4.0"
 ---
 
 # Celopedia Skill
@@ -77,7 +77,7 @@ B2B fiat-to-stablecoin infrastructure on Celo — virtual accounts, payouts, car
 
 ### 4. MiniPay App Builder
 
-Build Mini Apps for MiniPay — Celo's stablecoin wallet with 14M+ users.
+Build Mini Apps for MiniPay — Celo's stablecoin wallet with 16M+ users.
 
 - MiniPay detection (`window.ethereum.isMiniPay`)
 - Auto-connect patterns (no connect button in MiniPay)
@@ -97,10 +97,13 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 14M+ users.
 Build AI agents that transact on Celo.
 
 - **ERC-8004**: Agent Trust Protocol (identity + reputation registries)
+- **Self Agent ID**: proof-of-human extension on ERC-8004 (soulbound NFT bound to a ZK passport proof) — sybil resistance; register at `https://app.ai.self.xyz`
+- **Celo Agent Visa**: tiered program (Tourist → Work Visa → Citizenship) unlocking DeFi incentives, liquidity, and MiniPay reach — `https://agentvisa.self.xyz/agents/visa`
 - **x402**: HTTP-native micropayments with stablecoins
 - **Celo MCP Server**: Query blockchain data from coding assistants
 - **Agent Skills**: Modular skill system for AI coding agents
-- Use cases: FX arbitrage, prediction markets, automated payments
+- **Onchain Agents Hackathon** (May 22 – Jun 15, 2026, $5K in CELO): build payment-native agents; submit via the **Celo Builders skill** (`npx skills add https://celobuilders.xyz`) — `https://bit.ly/OnchainAgentsHackathon`
+- Use cases (push toward **onchain agents** that transact in stablecoins): consumer money (savings, remittance, bill-pay, FX hedging), agentic commerce, DeFAI, prediction markets, freelancer/invoice agents
 
 **References**: `ai-agents.md`
 

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -351,18 +351,56 @@ Skills activate automatically based on project context (e.g., `hardhat.config.ts
 
 ---
 
+## Self Agent ID: Proof-of-Human for Agents
+
+Self Agent ID is the **proof-of-human extension on top of ERC-8004**: a soulbound NFT that binds an agent's key to a unique human, proven by a zero-knowledge passport check via Self Protocol. It makes an agent **sybil-resistant** (one human, one identity) without exposing any personal data — only a ZK proof and a nullifier go on-chain.
+
+- **Why it matters**: required for the Celo Agent Visa Work tier, scored in Proof of Ship's AI Agents prize, and the trust primitive for agent-to-agent / agent-to-service flows.
+- **Flow**: human scans passport in the Self app (proof generated locally) → on-chain verification → registry mints a soulbound NFT bound to the human's nullifier → the agent signs requests with the bound key.
+- **Register**: web UI at `https://app.ai.self.xyz/register`, CLI, or REST API. Registration modes include wallet-linked, wallet-free, agent keypair, passkey smart wallet, and social (Privy).
+- **Networks**: Celo Mainnet (real passport) and Celo Sepolia (mock documents for testing). Cross-links the ERC-8004 Identity Registry above.
+- **Docs**: https://docs.self.xyz/self-agent-id · register at https://app.ai.self.xyz
+
+---
+
+## Celo Agent Visa
+
+A tiered program for AI agents that transact on Celo — the further your agent goes, the more ecosystem support it unlocks. Apply at **https://agentvisa.self.xyz/agents/visa**.
+
+| Tier | Requirements | Unlocks |
+|------|--------------|---------|
+| **Tourist** | ≥1 transaction on Celo (automatic) | Co-marketing + founder mentorship |
+| **Work Visa** | Self Agent ID verification · 1,000+ txns · $5K+ volume (or 1,000 unique contracts) · live product with real utility | DeFi incentives, liquidity support, featured placement |
+| **Citizenship** | Work Visa criteria + 10,000+ txns or $15K+ volume · manual review | Flagship support, deepest integrations |
+
+Benefits across tiers include access to MiniPay's 16M+ users, DeFi incentives (Uniswap, Aave, Mento, Velodrome), token-launch liquidity, mentorship, and co-marketing. Self Agent ID is the gate for the Work tier — register it first.
+
+---
+
 ## AI Agent Use Cases on Celo
 
-Key opportunities for AI agents on Celo:
+Celo is **actively pushing builders toward onchain agents** — agents that hold a wallet, transact in stablecoins, and generate real on-chain activity (not just chatbots). The strongest use cases are payment-native and emerging-market-first. Keep your scope broad; the wedge that wins is usually "an everyday money task, automated, settled in stablecoins."
 
-- **Onchain FX Trading**: Arbitrage bots across Mento stablecoin pairs, LP management on Uniswap, Merkl rewards optimization
-- **Prediction Markets**: Automated market making and trading
-- **Automated Savings/DCA**: Dollar-cost averaging into CELO or stablecoins
-- **Data Collection Payments**: x402 micropayments for data (82.7% data gap outside NA/Europe)
-- **Retroactive Funding Optimization**: Track Proof-of-Ship metrics via Karma dashboard
-- **Payment Agents**: Autonomous bill payment, remittance, payroll
+- **Consumer money (save / send / spend)**: savings-coach and round-up agents, group savings (chama / stokvel) pools, remittance concierge, bill-pay & autopay, FX-hedging agents that dollarize a local-currency paycheck. Highest PMF — emerging-market retail.
+- **Agentic commerce & marketplaces**: local-commerce concierge with escrow, cross-border shopping agents, subscription managers — settling via x402 micropayments.
+- **DeFAI (crypto-native)**: conversational DeFi agents that compose Mento + Aave + Ubeswap, set-and-forget yield optimizers, DCA / strategy agents, onchain tax & portfolio assistants.
+- **Social, predictions & viral**: localized prediction markets, tip-to-earn creator agents, donation / round-up-to-cause agents.
+- **SMB, freelancers & identity infra**: invoice / get-paid agents, sybil-resistant airdrop & quest tools, SMS/USSD wallets for feature phones, and an MCP server for Celo. Pair human- or operator-facing flows with **Self Agent ID** for trust.
+
+Many of these benefit from **Self Agent ID** (one-human-one-spot) to prevent sybil/ghost-account fraud, and qualify for the **Agent Visa** and **Proof of Ship** AI agent tracks once live on mainnet.
 
 **Resources:**
-- Agent ideas: https://github.com/celo-org/ai-agent-ideas
+- ERC-8004 + Self Agent ID + x402 (above) are the core building blocks
 - Uniswap pools: https://app.uniswap.org/explore/pools/celo
 - Merkl rewards: https://merkl.angle.money/?chain=42220
+
+---
+
+## Onchain Agents Hackathon
+
+A Celo DevRel-run hackathon for building onchain agents focused on **real-world payments and everyday applications** — May 22 – June 15, 2026, **$5K prize pool in CELO**. Winning agents generate real transactions and demonstrate genuine on-chain utility (not prototypes). Full details: **https://bit.ly/OnchainAgentsHackathon**
+
+- **Tracks**: Best Agent on Celo ($2,500 / $1,000 / $500) · Most Activity — onchain transactions ($500) · Highest 8004scan rank ($500). Activity/rank tracks combine with the main track.
+- **Register**: quote-tweet the announcement tagging @CeloDevs + @Celo, describe what you're building, and include your ERC-8004 registry link. Join the Telegram for updates.
+- **Verification**: Self Agent ID is beneficial (helps judges sort out sybil attempts); not strictly required where Self isn't available in your region.
+- **Submit**: through the **Celo Builders skill** — install it with `npx skills add https://celobuilders.xyz`, then ask your coding agent to submit (hackathon: `celo-onchain-agents`). The skill walks you through connecting, answering project questions, reviewing the draft, and publishing.

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -390,7 +390,7 @@ Celo is **actively pushing builders toward onchain agents** — agents that hold
 Many of these benefit from **Self Agent ID** (one-human-one-spot) to prevent sybil/ghost-account fraud, and qualify for the **Agent Visa** and **Proof of Ship** AI agent tracks once live on mainnet.
 
 **Resources:**
-- ERC-8004 + Self Agent ID + x402 (above) are the core building blocks
+- Agent ideas: https://github.com/celo-org/ai-agent-ideas
 - Uniswap pools: https://app.uniswap.org/explore/pools/celo
 - Merkl rewards: https://merkl.angle.money/?chain=42220
 

--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -45,35 +45,18 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 
 ### Allowed Fee Currencies (Mainnet)
 
-The allowlist is the **on-chain source of truth** — query `getCurrencies()` (below) for the live set. As of the last on-chain check it holds **20 fee currencies**: USDm, USDC, and USDT plus a wide set of Mento local-currency stablecoins (EURm, BRLm, KESm, COPm, GHSm, NGNm, ZARm, GBPm, CADm, AUDm, CHFm, JPYm, XOFm, PHPm), and WETH, XAUt0, USAT.
-
-**Important**: USDC and USDT use 6 decimals, so they require **adapter contracts** that normalize to 18 decimals. Use the **adapter** address (not the token address) in the `feeCurrency` field. Every other entry is 18-decimal, so its token address **is** its `feeCurrency` address.
+**Important**: USDC and USDT use 6 decimals, so they require **adapter contracts** that normalize to 18 decimals. Use the adapter address (not the token address) in the `feeCurrency` field.
 
 | Token | Decimals | Token Address | feeCurrency Address |
 |-------|----------|---------------|---------------------|
 | USDm (cUSD) | 18 | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | `0x765DE816845861e75A25fCA122bb6898B8B1282a` (same) |
-| USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
-| USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
 | EURm (cEUR) | 18 | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` (same) |
 | BRLm (cREAL) | 18 | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` (same) |
-| KESm (cKES) | 18 | `0x456a3D042C0DbD3db53D5489e98dFb038553B0d0` | `0x456a3D042C0DbD3db53D5489e98dFb038553B0d0` (same) |
-| COPm (cCOP) | 18 | `0x8A567e2aE79CA692Bd748aB832081C45de4041eA` | `0x8A567e2aE79CA692Bd748aB832081C45de4041eA` (same) |
-| GHSm (cGHS) | 18 | `0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313` | `0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313` (same) |
-| NGNm (cNGN) | 18 | `0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71` | `0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71` (same) |
-| ZARm (cZAR) | 18 | `0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6` | `0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6` (same) |
-| GBPm (cGBP) | 18 | `0xCCF663b1fF11028f0b19058d0f7B674004a40746` | `0xCCF663b1fF11028f0b19058d0f7B674004a40746` (same) |
-| CADm (cCAD) | 18 | `0xff4Ab19391af240c311c54200a492233052B6325` | `0xff4Ab19391af240c311c54200a492233052B6325` (same) |
-| AUDm (cAUD) | 18 | `0x7175504C455076F15c04A2F90a8e352281F492F9` | `0x7175504C455076F15c04A2F90a8e352281F492F9` (same) |
-| CHFm (cCHF) | 18 | `0xb55a79F398E759E43C95b979163f30eC87Ee131D` | `0xb55a79F398E759E43C95b979163f30eC87Ee131D` (same) |
-| JPYm (cJPY) | 18 | `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20` | `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20` (same) |
-| XOFm (cXOF) | 18 | `0x73F93dcc49cB8A239e2032663e9475dd5ef29A08` | `0x73F93dcc49cB8A239e2032663e9475dd5ef29A08` (same) |
-| PHPm (PUSO) | 18 | `0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B` | `0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B` (same) |
-| WETH | 18 | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` (same) |
-| XAUt0 (Tether Gold) | 18 | `0x857BF24e29da0773687E804a743c2E421a394C16` | `0x857BF24e29da0773687E804a743c2E421a394C16` (same) |
-| USAT | 18 | `0x0357EE22278c922e1D36cFe6b899269b161880C4` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (same) |
+| USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
+| USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
 
-> Practical guidance: for MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold — default to those. The Mento local-currency stablecoins and other assets above are valid fee currencies too, but rarely the right UX default. The list changes over time; treat `getCurrencies()` as canonical and don't hardcode it.
->
+The table above is the common subset. The **full allowlist is larger** — it also includes many Mento local-currency stablecoins (KESm, COPm, GHSm, NGNm, ZARm, GBPm, and more) plus a few other assets. Rather than hardcode the whole list, **fetch it live** with `getCurrencies()` (see below) — that's the canonical, always-current source. For MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold, so default to those.
+
 > **Wallet/SDK support:** fee abstraction works in MiniPay-focused and Celo-native wallets (MiniPay, Valora) today, with **Ledger support coming soon**. On the SDK side, **viem** supports the `feeCurrency` field natively — **ethers.js and web3.js do not**.
 
 The `FeeCurrencyDirectory` contract at `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` governs the allowlist. Query it:

--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -57,7 +57,7 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 
 The table above is the common subset. The **full allowlist is larger** — it also includes many Mento local-currency stablecoins (KESm, COPm, GHSm, NGNm, ZARm, GBPm, and more) plus a few other assets. Rather than hardcode the whole list, **fetch it live** with `getCurrencies()` (see below) — that's the canonical, always-current source. For MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold, so default to those.
 
-> **Wallet/SDK support:** fee abstraction works in MiniPay-focused and Celo-native wallets (MiniPay, Valora) today, with **Ledger support coming soon**. On the SDK side, **viem** supports the `feeCurrency` field natively — **ethers.js and web3.js do not**.
+> **Wallet/SDK support:** fee abstraction works in Celo-native wallets (MiniPay, Valora) today, with **Ledger support coming soon**. On the SDK side, **viem** supports the `feeCurrency` field natively — **ethers.js and web3.js do not**.
 
 The `FeeCurrencyDirectory` contract at `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` governs the allowlist. Query it:
 

--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -45,15 +45,36 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 
 ### Allowed Fee Currencies (Mainnet)
 
-**Important**: USDC and USDT use 6 decimals, so they require **adapter contracts** that normalize to 18 decimals. Use the adapter address (not the token address) in the `feeCurrency` field.
+The allowlist is the **on-chain source of truth** — query `getCurrencies()` (below) for the live set. As of the last on-chain check it holds **20 fee currencies**: USDm, USDC, and USDT plus a wide set of Mento local-currency stablecoins (EURm, BRLm, KESm, COPm, GHSm, NGNm, ZARm, GBPm, CADm, AUDm, CHFm, JPYm, XOFm, PHPm), and WETH, XAUt0, USAT.
+
+**Important**: USDC and USDT use 6 decimals, so they require **adapter contracts** that normalize to 18 decimals. Use the **adapter** address (not the token address) in the `feeCurrency` field. Every other entry is 18-decimal, so its token address **is** its `feeCurrency` address.
 
 | Token | Decimals | Token Address | feeCurrency Address |
 |-------|----------|---------------|---------------------|
 | USDm (cUSD) | 18 | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | `0x765DE816845861e75A25fCA122bb6898B8B1282a` (same) |
-| EURm (cEUR) | 18 | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` (same) |
-| BRLm (cREAL) | 18 | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` (same) |
 | USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
 | USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
+| EURm (cEUR) | 18 | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` (same) |
+| BRLm (cREAL) | 18 | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` (same) |
+| KESm (cKES) | 18 | `0x456a3D042C0DbD3db53D5489e98dFb038553B0d0` | `0x456a3D042C0DbD3db53D5489e98dFb038553B0d0` (same) |
+| COPm (cCOP) | 18 | `0x8A567e2aE79CA692Bd748aB832081C45de4041eA` | `0x8A567e2aE79CA692Bd748aB832081C45de4041eA` (same) |
+| GHSm (cGHS) | 18 | `0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313` | `0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313` (same) |
+| NGNm (cNGN) | 18 | `0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71` | `0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71` (same) |
+| ZARm (cZAR) | 18 | `0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6` | `0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6` (same) |
+| GBPm (cGBP) | 18 | `0xCCF663b1fF11028f0b19058d0f7B674004a40746` | `0xCCF663b1fF11028f0b19058d0f7B674004a40746` (same) |
+| CADm (cCAD) | 18 | `0xff4Ab19391af240c311c54200a492233052B6325` | `0xff4Ab19391af240c311c54200a492233052B6325` (same) |
+| AUDm (cAUD) | 18 | `0x7175504C455076F15c04A2F90a8e352281F492F9` | `0x7175504C455076F15c04A2F90a8e352281F492F9` (same) |
+| CHFm (cCHF) | 18 | `0xb55a79F398E759E43C95b979163f30eC87Ee131D` | `0xb55a79F398E759E43C95b979163f30eC87Ee131D` (same) |
+| JPYm (cJPY) | 18 | `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20` | `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20` (same) |
+| XOFm (cXOF) | 18 | `0x73F93dcc49cB8A239e2032663e9475dd5ef29A08` | `0x73F93dcc49cB8A239e2032663e9475dd5ef29A08` (same) |
+| PHPm (PUSO) | 18 | `0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B` | `0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B` (same) |
+| WETH | 18 | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` (same) |
+| XAUt0 (Tether Gold) | 18 | `0x857BF24e29da0773687E804a743c2E421a394C16` | `0x857BF24e29da0773687E804a743c2E421a394C16` (same) |
+| USAT | 18 | `0x0357EE22278c922e1D36cFe6b899269b161880C4` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (same) |
+
+> Practical guidance: for MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold — default to those. The Mento local-currency stablecoins and other assets above are valid fee currencies too, but rarely the right UX default. The list changes over time; treat `getCurrencies()` as canonical and don't hardcode it.
+>
+> **Wallet/SDK support:** fee abstraction works in MiniPay-focused and Celo-native wallets (MiniPay, Valora) today, with **Ledger support coming soon**. On the SDK side, **viem** supports the `feeCurrency` field natively — **ethers.js and web3.js do not**.
 
 The `FeeCurrencyDirectory` contract at `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` governs the allowlist. Query it:
 

--- a/skills/celopedia-skill/references/contracts.md
+++ b/skills/celopedia-skill/references/contracts.md
@@ -66,8 +66,11 @@ All addresses verified from official Celo documentation. **Do not guess addresse
 |-------|--------|---------|
 | USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
 | Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
+| Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
 | Wrapped Ether | WETH | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` |
 | CELO (ERC-20) | CELO | `0x471EcE3750Da237f93B8E339c536989b8978a438` |
+
+> **USAT** (Tether America USD) launched on Celo in April 2026 — a USD stablecoin backed by short-term T-bills + cash (supervised by Anchorage Digital). **6 decimals** (like USDC/USDT). It is a whitelisted fee currency; its `feeCurrency` adapter is `0x0357EE22278c922e1D36cFe6b899269b161880C4` (18-decimal adapter — use the adapter, not the token, in the `feeCurrency` field). Caveat: upstream price oracles don't yet index the Celo contract address, so Valora-derived wallets may show `priceUsd: NaN` until that's resolved.
 
 ---
 

--- a/skills/celopedia-skill/references/contracts.md
+++ b/skills/celopedia-skill/references/contracts.md
@@ -67,12 +67,22 @@ All addresses verified from official Celo documentation. **Do not guess addresse
 | USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
 | Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
 | Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
-| Mountain Protocol USD | USDM | `0x59d9356E565Ab3A36dD77763Fc0d87fEAf85508C` |
+| Mountain Protocol USD | USDM | `0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C` |
 | Angle USD | USDA | `0x0000206329b97DB379d5E1Bf586BbDB969C63274` |
+| Angle Euro | EURA | `0xC16B81Af351BA9e64C1a069E3Ab18c244A1E3049` |
+| VNX Euro | VEUR | `0x9346F43c1588B6DF1D52bdD6Bf846064F92d9Cba` |
+| VNX British Pound | VGBP | `0x7aE4265eCFC1F31bc0E112DfCFe3D78E01f4BB7f` |
+| VNX Swiss Franc | VCHF | `0xC5ebEa9984C485EC5D58cA5a2D376620d93aF871` |
+| Glo Dollar | USDGLO | `0x4F604735c1cF31399C6E711D5962b2B3E0225AD3` |
+| BRLA Digital | BRLA | `0xFECB3F7c54E2CAAE9dC6Ac9060A822D47E053760` |
+| Minteo Colombian Peso | COPM | `0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606` |
+| GoodDollar | G$ | `0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A` |
 | Wrapped Ether | WETH | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` |
 | CELO (ERC-20) | CELO | `0x471EcE3750Da237f93B8E339c536989b8978a438` |
 
-> **`USDM` (Mountain Protocol) ≠ `USDm` (Celo cUSD).** Mountain's USDM is a separate yield-bearing, US-Treasury-backed stablecoin (18 decimals) — not the Mento dollar. Other third-party issuers: **VNX** (VEUR / VCHF / VGBP stablecoins + VNXAU gold — verify addresses on Celoscan), **Angle** (USDA above, plus EURA).
+> Third-party stablecoins above are sourced from and verified against the official list: https://docs.celo.org/build-on-celo/build-with-local-stablecoin (addresses confirmed on-chain).
+>
+> **Ticker collisions to watch** (match on address, not symbol): Mountain Protocol's **USDM** (yield-bearing, US-Treasury-backed) is **not** Celo's **USDm** (cUSD, the Mento dollar). Minteo's **COPM** (`0xC92E…`) is **not** Mento's **COPm** (`0x8A56…`).
 
 > **USAT** (Tether America USD) launched on Celo in April 2026 — a USD stablecoin backed by short-term T-bills + cash (supervised by Anchorage Digital). **6 decimals** (like USDC/USDT). It is a whitelisted fee currency; its `feeCurrency` adapter is `0x0357EE22278c922e1D36cFe6b899269b161880C4` (18-decimal adapter — use the adapter, not the token, in the `feeCurrency` field). Caveat: upstream price oracles don't yet index the Celo contract address, so Valora-derived wallets may show `priceUsd: NaN` until that's resolved.
 

--- a/skills/celopedia-skill/references/contracts.md
+++ b/skills/celopedia-skill/references/contracts.md
@@ -67,8 +67,12 @@ All addresses verified from official Celo documentation. **Do not guess addresse
 | USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
 | Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
 | Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
+| Mountain Protocol USD | USDM | `0x59d9356E565Ab3A36dD77763Fc0d87fEAf85508C` |
+| Angle USD | USDA | `0x0000206329b97DB379d5E1Bf586BbDB969C63274` |
 | Wrapped Ether | WETH | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` |
 | CELO (ERC-20) | CELO | `0x471EcE3750Da237f93B8E339c536989b8978a438` |
+
+> **`USDM` (Mountain Protocol) ≠ `USDm` (Celo cUSD).** Mountain's USDM is a separate yield-bearing, US-Treasury-backed stablecoin (18 decimals) — not the Mento dollar. Other third-party issuers: **VNX** (VEUR / VCHF / VGBP stablecoins + VNXAU gold — verify addresses on Celoscan), **Angle** (USDA above, plus EURA).
 
 > **USAT** (Tether America USD) launched on Celo in April 2026 — a USD stablecoin backed by short-term T-bills + cash (supervised by Anchorage Digital). **6 decimals** (like USDC/USDT). It is a whitelisted fee currency; its `feeCurrency` adapter is `0x0357EE22278c922e1D36cFe6b899269b161880C4` (18-decimal adapter — use the adapter, not the token, in the `feeCurrency` field). Caveat: upstream price oracles don't yet index the Celo contract address, so Valora-derived wallets may show `priceUsd: NaN` until that's resolved.
 

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -117,25 +117,27 @@ Celo is known as the "Home of Stablecoins" with 15+ Mento local-currency stablec
 | Philippine Peso | PHPm | Philippines |
 | South African Rand | ZARm | South Africa |
 
-### External Stablecoins
+### External & third-party stablecoins
 
-| Token | Symbol | Address |
-|-------|--------|---------|
-| USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
-| Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
-| Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
-| Mountain Protocol USD | USDM | `0x59d9356E565Ab3A36dD77763Fc0d87fEAf85508C` |
-| Angle USD | USDA | `0x0000206329b97DB379d5E1Bf586BbDB969C63274` |
+Sourced from the official list (https://docs.celo.org/build-on-celo/build-with-local-stablecoin), addresses verified on-chain. See `contracts.md` for the full table.
 
-> ⚠️ **`USDM` ≠ `USDm`.** Mountain Protocol's **USDM** (uppercase M, yield-bearing, backed by short-term US Treasuries, 18 decimals, `0x59d9…508C`) is a **different token** from Celo's **USDm** (cUSD, the Mento dollar). Don't conflate them.
+| Token | Symbol | Issuer | Address |
+|-------|--------|--------|---------|
+| USDC | USDC | Circle | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
+| Tether USD | USDT | Tether | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
+| Tether America USD | USAT | Tether | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
+| Mountain Protocol USD | USDM | Mountain Protocol | `0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C` |
+| Angle USD | USDA | Angle | `0x0000206329b97DB379d5E1Bf586BbDB969C63274` |
+| Angle Euro | EURA | Angle | `0xC16B81Af351BA9e64C1a069E3Ab18c244A1E3049` |
+| VNX Euro | VEUR | VNX | `0x9346F43c1588B6DF1D52bdD6Bf846064F92d9Cba` |
+| VNX British Pound | VGBP | VNX | `0x7aE4265eCFC1F31bc0E112DfCFe3D78E01f4BB7f` |
+| VNX Swiss Franc | VCHF | VNX | `0xC5ebEa9984C485EC5D58cA5a2D376620d93aF871` |
+| Glo Dollar | USDGLO | Glo Foundation | `0x4F604735c1cF31399C6E711D5962b2B3E0225AD3` |
+| BRLA Digital | BRLA | BRLA | `0xFECB3F7c54E2CAAE9dC6Ac9060A822D47E053760` |
+| Minteo Colombian Peso | COPM | Minteo | `0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606` |
+| GoodDollar | G$ | GoodDollar | `0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A` |
 
-### Other stablecoin & RWA issuers
-
-| Issuer | Tokens on Celo | Notes |
-|--------|----------------|-------|
-| Mountain Protocol | USDM | Yield-bearing USD, US-Treasury backed — https://mountainprotocol.com |
-| Angle | USDA (+ stUSD), EURA | Over-collateralized stable protocol — https://angle.money |
-| VNX | VEUR, VCHF, VGBP, VNXAU (gold) | EUR/CHF/GBP stablecoins + tokenized gold — https://vnx.li (verify token addresses on Celoscan) |
+> ⚠️ **Ticker collisions** (match on address, not symbol): Mountain Protocol's **USDM** (yield-bearing, US-Treasury backed, `0x59D9…508C`) ≠ Celo's **USDm** (cUSD, the Mento dollar). Minteo's **COPM** (`0xC92E…`) ≠ Mento's **COPm**.
 
 ---
 

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -124,6 +124,18 @@ Celo is known as the "Home of Stablecoins" with 15+ Mento local-currency stablec
 | USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
 | Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
 | Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
+| Mountain Protocol USD | USDM | `0x59d9356E565Ab3A36dD77763Fc0d87fEAf85508C` |
+| Angle USD | USDA | `0x0000206329b97DB379d5E1Bf586BbDB969C63274` |
+
+> ⚠️ **`USDM` ≠ `USDm`.** Mountain Protocol's **USDM** (uppercase M, yield-bearing, backed by short-term US Treasuries, 18 decimals, `0x59d9…508C`) is a **different token** from Celo's **USDm** (cUSD, the Mento dollar). Don't conflate them.
+
+### Other stablecoin & RWA issuers
+
+| Issuer | Tokens on Celo | Notes |
+|--------|----------------|-------|
+| Mountain Protocol | USDM | Yield-bearing USD, US-Treasury backed — https://mountainprotocol.com |
+| Angle | USDA (+ stUSD), EURA | Over-collateralized stable protocol — https://angle.money |
+| VNX | VEUR, VCHF, VGBP, VNXAU (gold) | EUR/CHF/GBP stablecoins + tokenized gold — https://vnx.li (verify token addresses on Celoscan) |
 
 ---
 

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -97,6 +97,8 @@ Celo is known as the "Home of Stablecoins" with 15+ Mento local-currency stablec
 
 ### Mento Stablecoins (see contracts.md for addresses)
 
+> Canonical list + how to build with them: https://docs.celo.org/build-on-celo/build-with-local-stablecoin
+
 | Currency | Symbol | Region |
 |----------|--------|--------|
 | US Dollar | USDm (cUSD) | Global |
@@ -117,10 +119,11 @@ Celo is known as the "Home of Stablecoins" with 15+ Mento local-currency stablec
 
 ### External Stablecoins
 
-| Token | Symbol |
-|-------|--------|
-| USDC (Circle) | USDC |
-| Tether USD | USDT |
+| Token | Symbol | Address |
+|-------|--------|---------|
+| USDC (Circle) | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
+| Tether USD | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
+| Tether America USD | USAT | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` |
 
 ---
 

--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -6,7 +6,7 @@
 >
 > For the full page-by-page index of `docs.minipay.xyz`, see `minipay-docs-map.md`.
 
-MiniPay is a non-custodial stablecoin wallet integrated into Opera Mini and available as a standalone app on Android and iOS. It's the fastest growing wallet in the Global South with 14M+ activations, 300M+ stablecoin transactions, available in 60+ countries.
+MiniPay is a non-custodial stablecoin wallet integrated into Opera Mini and available as a standalone app on Android and iOS. It's the fastest growing wallet in the Global South with 16M+ activations, 470M+ stablecoin transactions, 15M+ monthly Mini App opens, available in 66+ countries.
 
 > Wallet counts are updated by the MiniPay team via the MiniPay site and Celo blog. If a precise current number is needed, prefer fetching from those sources over the number above.
 
@@ -41,6 +41,20 @@ npx @celo/celo-composer@latest create -t minipay
 ```bash
 npm install viem@2 @celo/abis @celo/identity
 ```
+
+---
+
+## Quickstart: Utility Payment Mini App
+
+A common starting point — a Mini App where users pay a bill or send a stablecoin payment. The pieces below are documented in detail elsewhere in this guide; this is the order to wire them up. Mini Apps are **stablecoin-first**: build payment flows around USDm, USDC, and USDT (with gas paid in those same stablecoins via fee abstraction), so users never need to hold CELO.
+
+1. **Scaffold** — `npx @celo/celo-composer@latest create -t minipay` (or the raw Next.js path in `minipay-scaffold-from-scratch.md`).
+2. **Detect MiniPay & auto-connect** — `window.ethereum.isMiniPay`, no connect button (see _MiniPay Detection_ + _Wallet Connection_ above).
+3. **Pick the user's stablecoin** — read USDm/USDC/USDT balances and default to the one they hold (see _Supported Stablecoins_ + _Check Token Balance_). Mind decimals (USDm = 18, USDC/USDT = 6).
+4. **Pay gas in stablecoins** — set `feeCurrency` so the user pays network fees in the same stablecoin; use the **adapter** address for USDC/USDT. See `builder-guide.md` → _Allowed Fee Currencies_.
+5. **Build the payment flow** — approval + transfer for the bill/payment; reuse the **Bill Payment** and **Stablecoin Payment Flow** templates in `minipay-templates.md`.
+6. **Test on a physical device** — ngrok + a real Android/iOS phone (emulators do not work).
+7. **Submit** — when ready, go through the two-stage MiniPay listing at `https://minipay.to/mini-apps` (see `minipay-requirements.md`).
 
 ---
 

--- a/skills/celopedia-skill/references/minipay-guide.md
+++ b/skills/celopedia-skill/references/minipay-guide.md
@@ -44,20 +44,6 @@ npm install viem@2 @celo/abis @celo/identity
 
 ---
 
-## Quickstart: Utility Payment Mini App
-
-A common starting point — a Mini App where users pay a bill or send a stablecoin payment. The pieces below are documented in detail elsewhere in this guide; this is the order to wire them up. Mini Apps are **stablecoin-first**: build payment flows around USDm, USDC, and USDT (with gas paid in those same stablecoins via fee abstraction), so users never need to hold CELO.
-
-1. **Scaffold** — `npx @celo/celo-composer@latest create -t minipay` (or the raw Next.js path in `minipay-scaffold-from-scratch.md`).
-2. **Detect MiniPay & auto-connect** — `window.ethereum.isMiniPay`, no connect button (see _MiniPay Detection_ + _Wallet Connection_ above).
-3. **Pick the user's stablecoin** — read USDm/USDC/USDT balances and default to the one they hold (see _Supported Stablecoins_ + _Check Token Balance_). Mind decimals (USDm = 18, USDC/USDT = 6).
-4. **Pay gas in stablecoins** — set `feeCurrency` so the user pays network fees in the same stablecoin; use the **adapter** address for USDC/USDT. See `builder-guide.md` → _Allowed Fee Currencies_.
-5. **Build the payment flow** — approval + transfer for the bill/payment; reuse the **Bill Payment** and **Stablecoin Payment Flow** templates in `minipay-templates.md`.
-6. **Test on a physical device** — ngrok + a real Android/iOS phone (emulators do not work).
-7. **Submit** — when ready, go through the two-stage MiniPay listing at `https://minipay.to/mini-apps` (see `minipay-requirements.md`).
-
----
-
 ## MiniPay Detection
 
 Check if your dApp is running inside MiniPay:


### PR DESCRIPTION
## What

Expands agent + MiniPay coverage and refreshes the fee-currency reference.

### AI agents (`ai-agents.md`, `SKILL.md`, `README.md`)
- **Self Agent ID** — new section: proof-of-human extension on ERC-8004 (soulbound NFT bound to a ZK passport proof), registration flow/modes, networks. Register at `app.ai.self.xyz`.
- **Celo Agent Visa** — new section: Tourist / Work Visa / Citizenship tiers with requirements + benefits. Apply at `agentvisa.self.xyz/agents/visa`.
- **Use cases broadened** to push **onchain, payment-native agents** (consumer money, agentic commerce, DeFAI, predictions, SMB/identity infra) instead of the old short list.
- **Onchain Agents Hackathon** — new entry (May 22 – Jun 15, 2026, $5K in CELO, tracks, registration). Submission is via the **Celo Builders skill** (`npx skills add https://celobuilders.xyz`), not Celopedia.

### Fee currencies (`builder-guide.md`)
- Keep the **common-subset table** (USDm, EURm, BRLm, USDC, USDT) and add a note that the **full allowlist is larger** (Mento local-currency stablecoins + others) — readers fetch the complete, always-current set via `FeeCurrencyDirectory.getCurrencies()` rather than a hardcoded list. (Verified the live allowlist on mainnet: 20 currencies.)
- Added wallet/SDK support note: MiniPay/Valora today, **Ledger coming soon**; `viem` supports `feeCurrency`, ethers/web3 do not.

### MiniPay stats refresh
- Updated stale figures to current: **16M+ wallets, 470M+ transactions, 66+ countries** (+15M+ monthly Mini App opens) in `SKILL.md`, `minipay-guide.md`, `README.md`.

### Version
- `SKILL.md` bumped 2.3.1 → **2.4.0**.

## Sources
- Fee-currency allowlist: on-chain `getCurrencies()` on `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` (Celo mainnet).
- Agent Visa: celo.org/agent-visa · agentvisa.self.xyz
- Self Agent ID: docs.self.xyz/self-agent-id
- Hackathon: bit.ly/OnchainAgentsHackathon

## Notes
- Self Agent ID is also the subject of open PR #25 (`references/self-agent-id.md`). This PR adds a concise inline section in `ai-agents.md` instead of a dangling cross-link; if #25 lands, the two can be reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)