### PR TITLE
docs: add MiniPay performance playbook (measure load speed with PostHog + optimize)

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -91,7 +91,7 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 16M+ users.
 - **Official submission requirements**: `minipay-requirements.md` — listing is a **two-stage process**. Stage 1 is the public **intake form** at `https://minipay.to/mini-apps`; Stage 2 is the post-call **readiness form** (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA, etc.). Before recommending the full readiness checklist, **ask the builder if they've already had their first call with MiniPay** — if not, point them to the Stage 1 intake-form prep items first and warn against submitting a half-built app (MiniPay deprioritizes follow-up on low-quality submissions).
 - **App Fit & Priority Framework**: before building, use `minipay-app-fit.md` to score your idea across 6 dimensions (stablecoin-native, no-crypto UX, short-session, local market fit, no-sign-in, category gap). Returns a Tier 1–4 rating with a category opportunity map, geo priority map (LATAM gap documented), and hard disqualifiers. Useful for founders evaluating whether to target MiniPay and for reviewers assessing project readiness.
 
-**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`), `minipay-app-fit.md`
+**References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`), `minipay-app-fit.md`, `minipay-performance.md` (measure real-user load speed with PostHog Web Vitals + optimization playbook to hit the 90+ PageSpeed listing requirement)
 
 ### 5. AI Agent Builder
 
@@ -189,6 +189,7 @@ Start with `growth-diagnostic.md` — the 6-question diagnostic routes the build
 | MiniPay development | Check `minipay-guide.md`, `minipay-templates.md` |
 | Specific MiniPay docs page (`docs.minipay.xyz/...`) | Look up in `minipay-docs-map.md` |
 | MiniPay submission / listing readiness | Check `minipay-requirements.md` — ask first if they've had their MiniPay call. If not → Stage 1 intake prep. If yes → full Stage 2 checklist. |
+| MiniPay performance / load speed / Web Vitals / PageSpeed / slow first load | Check `minipay-performance.md` — measure real-user load speed with PostHog + optimization playbook to hit 90+ |
 | What Mini Apps are live / discovery ideas | Check `minipay-live-apps.md` (snapshot; country availability varies) |
 | ODIS / phone lookup / SocialConnect | Check `odis-socialconnect.md`, `minipay-guide.md`, `contracts.md` |
 | AI agent building | Check `ai-agents.md` |

--- a/skills/celopedia-skill/references/growth-analytics.md
+++ b/skills/celopedia-skill/references/growth-analytics.md
@@ -295,6 +295,8 @@ module.exports = async (req, res) => {
 
 The Graph and RPC tell you *what happened on-chain*. PostHog tells you *what the user did in the app before/after*. Both are necessary; neither replaces the other.
 
+> PostHog also measures **real-user load speed** (Core Web Vitals) — critical for MiniPay, where slow loads are an entry barrier. Enable it with `capture_performance: { web_vitals: true }` in `posthog.init`. Full measure-and-optimize playbook: `minipay-performance.md`.
+
 ### Step 1 — Add the PostHog snippet to every HTML page
 
 > Use the **project API key** (starts with `phc_`) — not the personal API key (`phx_`). Wrong key = silent failure, all zeros in dashboard.

--- a/skills/celopedia-skill/references/minipay-performance.md
+++ b/skills/celopedia-skill/references/minipay-performance.md
@@ -1,0 +1,178 @@
+# MiniPay Performance — Measure & Optimize Load Speed
+
+> Docs: https://docs.minipay.xyz/getting-started/best-practices.html (Performance) · https://pagespeed.web.dev · https://web.dev/articles/vitals · https://posthog.com/docs/web-analytics/web-vitals
+>
+> **Companion files:** `minipay-requirements.md` §4 (the listing requirement) · `growth-analytics.md` §6 (PostHog setup) · `defi-protocols.md` (the wallet SDKs whose weight this file helps you defer).
+
+## Why this matters (it's an entry barrier, not a nice-to-have)
+
+MiniPay users open Mini Apps **inside a webview, on mid-range Android phones, on mobile data in emerging markets**. A heavy first load is a hard filter: every extra second of load time drops a measurable share of first-time users before they ever see your app. MiniPay makes this explicit — a **PageSpeed Insights mobile score of 90+** is part of the submission, and low scores block listing (`minipay-requirements.md` §4).
+
+Treat load speed as a feature you ship and then **monitor continuously with real-user data**, not a one-time lab check.
+
+---
+
+## 1. Measure in two layers
+
+Lab and field measure different things — you need both.
+
+### Lab (controlled, for diagnosis)
+
+- **PageSpeed Insights** (`https://pagespeed.web.dev`, strategy: mobile) or **Lighthouse** in Chrome DevTools with throttling set to *Slow 4G* + *4× CPU*. This is the number MiniPay asks for, and it tells you exactly which asset is heavy.
+- Always test against a **mid-range device profile** (e.g. "Moto G Power" in DevTools), not your dev laptop. The lab number on a fast machine lies.
+
+### Field / RUM (real users — what actually matters for MiniPay)
+
+Lab is an idealized single run. **Real-user monitoring (RUM)** tells you what your actual MiniPay audience experiences on their phones and networks. PostHog gives you this for free and you very likely already have it installed for analytics (`growth-analytics.md`).
+
+**Enable Web Vitals capture** — this is off by default. Add `capture_performance` to your `posthog.init`:
+
+```js
+posthog.init('phc_YOUR_PROJECT_KEY', {
+  api_host: 'https://us.i.posthog.com',
+  person_profiles: 'always',
+  autocapture: true,
+  capture_performance: { web_vitals: true },   // ← emits one $web_vitals event per pageview
+});
+```
+
+PostHog then emits a `$web_vitals` event per pageview with `$web_vitals_LCP_value`, `$web_vitals_INP_value`, `$web_vitals_CLS_value`, `$web_vitals_FCP_value` (LCP/INP/FCP in ms, CLS unitless).
+
+### Read the p75 (Google's grading percentile) server-side
+
+Core Web Vitals are graded at the **75th percentile** of real users — not the average — so the number reflects the experience of most users *including* the slower ones. Query it with HogQL (keep your PostHog API key server-side; see `growth-analytics.md`):
+
+```sql
+SELECT
+  quantile(0.75)(toFloat(properties.$web_vitals_LCP_value)) AS lcp_p75,
+  quantile(0.75)(toFloat(properties.$web_vitals_INP_value)) AS inp_p75,
+  quantile(0.75)(toFloat(properties.$web_vitals_CLS_value)) AS cls_p75,
+  quantile(0.75)(toFloat(properties.$web_vitals_FCP_value)) AS fcp_p75,
+  count() AS samples
+FROM events
+WHERE event = '$web_vitals' AND timestamp >= now() - interval 1 day
+```
+
+**Window tip:** a **24h** window surfaces the impact of an optimization within a day; a 7-day window is more stable but lags — after you ship a fix it keeps averaging in days of old, slow traffic. Use a short window to confirm a change landed, a longer one for a stable baseline. With few samples (e.g. < ~30) the p75 is noisy — don't over-read a single day.
+
+### Core Web Vitals thresholds (p75)
+
+| Metric | Good | Needs improvement | Poor |
+|--------|------|-------------------|------|
+| **LCP** (Largest Contentful Paint) | ≤ 2.5 s | ≤ 4.0 s | > 4.0 s |
+| **INP** (Interaction to Next Paint) | ≤ 200 ms | ≤ 500 ms | > 500 ms |
+| **CLS** (Cumulative Layout Shift) | ≤ 0.1 | ≤ 0.25 | > 0.25 |
+| **FCP** (First Contentful Paint) | ≤ 1.8 s | ≤ 3.0 s | > 3.0 s |
+
+Surface these on your `/stats` page (which MiniPay wants anyway, `minipay-requirements.md` §8) so reviewers — and you — can see load speed at a glance and watch it after each deploy.
+
+---
+
+## 2. Optimize — the playbook (ordered by typical impact)
+
+These are the levers that most often move LCP/FCP for a MiniPay-style stack (static or SPA front end + a wallet/RPC layer). Verify each against your own RUM after shipping.
+
+### 🥇 Fix font loading — never `@import`
+
+Loading a web font with `@import url(...)` **inside your CSS** is one of the most common silent killers. It chains the requests: HTML → download CSS → *then* discover the `@import` → download the font CSS → download the font files. All serial, all blocking first paint.
+
+```css
+/* ❌ in styles.css — chained, blocks render */
+@import url('https://fonts.googleapis.com/css2?family=YourFont&display=swap');
+```
+
+```html
+<!-- ✅ in <head> — parallel with your stylesheet, preconnect warms the font host -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=YourFont&display=swap">
+```
+
+Always keep `&display=swap` so text renders immediately in a fallback font and swaps when the web font arrives. For the absolute fastest path, **self-host** the font files and `preload` the one weight you use above the fold. Even better for a webview: prefer a **system font stack** and skip web fonts entirely.
+
+### 🥈 Lazy-load the wallet SDK (huge MiniPay win)
+
+Wallet connection libraries (WalletConnect / Reown AppKit / wagmi and their connectors) are typically the **heaviest dependency in the bundle** — often hundreds of KB and dozens-to-hundreds of modules. **MiniPay injects `window.ethereum` and connects without any of them**, so for your primary audience this code is pure dead weight on first load.
+
+Don't import the wallet modal at module top level. Load it **on demand**, the first time a non-MiniPay user clicks "Connect":
+
+```js
+// Keep ethers/viem eager if you need it for read-only data on first paint.
+// Load the wallet modal stack only when actually needed.
+let _modal;
+async function ensureWalletModal() {
+  if (_modal) return _modal;
+  const { createAppKit } = await import('@reown/appkit');   // dynamic import → its own chunk
+  // ...create + configure the modal here, wire account subscription...
+  return (_modal = createAppKit(/* ... */));
+}
+
+connectButton.addEventListener('click', async () => {
+  const modal = await ensureWalletModal();   // first click pays the one-time cost
+  modal.open();
+});
+```
+
+Detect MiniPay early and skip the modal path entirely for those users:
+
+```js
+const inMiniPay = typeof window !== 'undefined' && window.ethereum?.isMiniPay;
+```
+
+Tradeoff: a returning desktop user with a persisted session reconnects on first click instead of automatically on load — acceptable for the bundle savings, and MiniPay users are unaffected.
+
+### 🥉 Defer non-critical scripts off the critical path
+
+Anything not needed for first paint should not block it: analytics, websocket clients, chat widgets, third-party SDKs.
+
+- Add `defer` to classic scripts; `type="module"` defers automatically.
+- Keep **dependency order**: deferred scripts execute in document order after parsing, so place a script that *defines* globals before the scripts that *consume* them.
+- Don't defer a script another inline script needs synchronously during parse — verify order after changing it.
+
+### Reserve space for late content (kills CLS)
+
+Layout shift comes from elements that appear *after* first paint and push content down. Two frequent culprits:
+
+- **Images without dimensions** — always set `width`/`height` attributes (or CSS `aspect-ratio`) so the browser reserves the box before the image loads.
+- **Headers/banners injected by JS** (a deferred script that mounts a nav) — give the placeholder a `min-height` equal to the final element so nothing jumps when it mounts.
+
+```html
+<img src="logo.webp" alt="Logo" width="168" height="168">
+<div id="app-header" style="min-height:64px"></div> <!-- reserved before JS injects the header -->
+```
+
+### Prioritize the LCP element
+
+Identify your Largest Contentful Paint element (usually the hero image or a large heading) in the Lighthouse report, then:
+
+```html
+<link rel="preload" as="image" href="hero.webp" fetchpriority="high">
+<!-- and on the element itself -->
+<img src="hero.webp" width="320" height="320" fetchpriority="high" alt="...">
+```
+
+### Preconnect to the origins you hit early
+
+Open the TCP+TLS handshake in parallel with parsing for the hosts you call on load — your RPC endpoint, your API, CDNs:
+
+```html
+<link rel="preconnect" href="https://forno.celo.org">
+<link rel="preconnect" href="https://your-cdn.example" crossorigin>
+```
+
+### Asset & bundle hygiene
+
+- Images in **WebP/AVIF or SVG**, never oversized PNG/JPG (`minipay-requirements.md` §4).
+- Split large i18n/translation blobs and heavy libs into separate chunks; load only what the current view needs.
+- Lazy-load below-the-fold images (`loading="lazy"`) and virtualize long lists.
+
+---
+
+## 3. Targets & verification
+
+- **PageSpeed Insights mobile ≥ 90** (the listing requirement). Re-run after each optimization.
+- **Core Web Vitals p75 all green**: LCP ≤ 2.5s, INP ≤ 200ms, CLS ≤ 0.1, FCP ≤ 1.8s.
+- Confirm wins with **field data** (PostHog p75), not just lab — the lab can pass while real users on slow networks still struggle.
+- Re-test on a **real mid-range Android inside MiniPay** (use ngrok + MiniPay's "Test Page", see `minipay-guide.md`), not just desktop Chrome.
+
+**Don't silently ship a regression:** a heavy dependency added later (a new chart lib, a wallet connector imported at top level again) can quietly undo these gains. Keep the Web Vitals card on your `/stats` page and watch it after each release.

--- a/skills/celopedia-skill/references/minipay-requirements.md
+++ b/skills/celopedia-skill/references/minipay-requirements.md
@@ -110,7 +110,7 @@ Replace crypto-jargon with user-friendly terms everywhere a real user sees them 
 
 - **Mobile-First Resolution** — the UI must be responsive and fully functional at **360w × 640h**. This is the hard minimum from the readiness PDF, and the smaller of the two figures floating in MiniPay's public material — design and verify against 360 × 640. Use Chrome DevTools device mode to validate before submission.
 - **Asset Optimization** — use **SVG or WebP** for images. Avoid PNG/JPG for anything larger than a few KB.
-- **Performance Benchmarking** — submit a **PageSpeed Insights** score (`https://pagespeed.web.dev`) for your production URL with the form. Aim for 90+ on mobile. Low scores block listing.
+- **Performance Benchmarking** — submit a **PageSpeed Insights** score (`https://pagespeed.web.dev`) for your production URL with the form. Aim for 90+ on mobile. Low scores block listing. **For how to measure real-user load speed (Web Vitals via PostHog) and the optimization playbook to actually hit 90+, see `minipay-performance.md`.**
 - **Network Transparency** — provide a full manifest of every **URL, subdomain, and origin** your app calls (JS, CSS, fonts, RPCs, APIs). MiniPay reviews this for supply-chain risk.
 
 ### 5. Smart Contract Standards


### PR DESCRIPTION
## Summary
Adds `references/minipay-performance.md` — a measure-and-optimize guide for Mini App load speed, which is a hard MiniPay listing requirement (PageSpeed mobile 90+) and a real entry barrier for users on mid-range Android over mobile data.

## Why
`minipay-requirements.md` §4 states the 90+ requirement but not *how* to hit it, and `growth-analytics.md` covers PostHog for behavior analytics but not Web Vitals / load speed. This fills that gap.

## Contents
- **Measure** in two layers: lab (PageSpeed/Lighthouse on a throttled mid-range profile) + field/RUM via **PostHog Web Vitals** — the `capture_performance` flag, `$web_vitals` events, a p75 HogQL query, CWV thresholds, and windowing caveats.
- **Optimization playbook** ordered by typical impact: fix font `@import` → parallel `<link>` + preconnect; **lazy-load the wallet SDK** (MiniPay injects `window.ethereum`, so WalletConnect/Reown/wagmi are dead weight on first load); defer non-critical scripts; reserve space to kill CLS; prioritize the LCP element; preconnect to RPC/CDN origins; asset/bundle hygiene.
- **Targets & verification** on a real device inside MiniPay.

## Also
Wires pointers from `minipay-requirements.md` §4, `growth-analytics.md` §6, and the `SKILL.md` reference list + routing table.

Docs-only change.