### PR TITLE
feat(contracts): add Ripio LatAm stablecoins to registries

### DIFF
--- a/.claude/skills/docs-watch/SKILL.md
+++ b/.claude/skills/docs-watch/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docs-watch
+description: Check docs.celo.org and other live sources for drift against this repo's cached reference files (contracts, network info, docs sitemap, ecosystem, grants) and fix or flag it. Use when asked to check docs updates, run the docs watch, or on the scheduled weekly run.
+---
+
+# celopedia-skills docs upstream watch
+
+Goal: detect when the facts mirrored into `skills/celopedia-skill/references/`
+have drifted from their live sources, and either fix the drift directly
+(mechanical changes) or flag it for a human (ambiguous/high-stakes changes) —
+following the process already documented in this repo's `README.md`
+("Contributing" section: check docs.celo.org → update the file → bump
+version → open a PR).
+
+## Sources checked
+
+| # | Source | Fetch command (see `live-data-sources.md` for more) | Reference file |
+|---|---|---|---|
+| 1 | Docs sitemap | `curl -s https://docs.celo.org/llms.txt` | `docs-map.md` |
+| 2 | Contract addresses | `https://docs.celo.org/tooling/contracts/core-contracts` + `token-contracts` + `l1-contracts` + `uniswap-contracts` (WebFetch) | `contracts.md` |
+| 3 | Network info | `https://docs.celo.org/build-on-celo/network-overview` (WebFetch) | `network-info.md` |
+| 4 | Ecosystem / TVL | `curl -s https://api.llama.fi/protocols \| jq '[.[] \| select(.chains[]? == "Celo")]'` | `ecosystem.md` |
+| 5 | Grant programs | `curl -s https://www.celopg.eco/programs` (WebFetch) | `grants-funding.md` |
+
+## Procedure
+
+1. **Load the snapshot** at `.claude/skills/docs-watch/snapshot.md` — the
+   facts we currently rely on, with the date each was last verified.
+
+2. **Fetch each source** above and extract the same facts the corresponding
+   reference file documents (page list, address table, chain params,
+   protocol list, program status table).
+
+3. **Diff** each source against both the snapshot and the current content of
+   its reference file.
+
+4. **Classify every delta:**
+   - `no action` — cosmetic/unrelated (e.g. a docs page's prose changed but
+     not its existence or URL).
+   - `reference update` — mechanical, unambiguous fact change: a sitemap page
+     added/removed/renamed, a DeFi protocol added/removed from the Celo chain
+     list, a grant program's Live/Past status flipped, a new fee-currency
+     token added. For these:
+     1. Edit the reference file directly with the corrected fact.
+     2. Bump `version` in `skills/celopedia-skill/SKILL.md` (patch bump for
+        pure data refresh).
+     3. Open a PR against `main` titled like `chore(docs): refresh <file> —
+        <one-line summary>`, following the README's Contributing steps.
+   - `needs review` — anything ambiguous or high-stakes (a contract address
+     that doesn't match, a chain ID / fee-currency address change, anything
+     touching `contracts.md` core protocol addresses or `network-info.md`
+     chain IDs). For these: do **not** edit the file. Open a GitHub issue in
+     `celo-org/celopedia-skills` describing exactly what was observed vs.
+     what's cached, and why it needs a human to confirm before changing.
+
+5. **Write the report** to `.claude/skills/docs-watch/reports/report-<YYYY-MM-DD>.md`
+   and commit it directly to `main` (a plain log entry, not something that
+   needs review) — this is the durable location, since a `.context/` file
+   would not survive between separate runs of a scheduled routine. One
+   section per source: deltas found, classification, and any PR/issue links
+   opened. Put a one-line "action needed?" summary at the top — if anything
+   is `needs review`, say so first.
+
+6. **Update the snapshot** with newly-verified facts and today's date. Keep
+   it small — only the facts checked above, not a full copy of the reference
+   files.
+
+## Notes
+
+- `live-data-sources.md` already documents the priority order (live API >
+  official docs > hardcoded references > ecosystem directory) — this skill
+  exists to keep the "hardcoded references" tier honest, not to replace live
+  lookups elsewhere.
+- Never guess a contract address or chain parameter to "fix" a `needs
+  review` item — that tier exists specifically so factual corrections to
+  security-sensitive data always get a human's eyes first.

--- a/.claude/skills/docs-watch/reports/report-2026-07-07.md
+++ b/.claude/skills/docs-watch/reports/report-2026-07-07.md
@@ -1,0 +1,48 @@
+# docs-watch report — 2026-07-07
+
+**Action needed?** No content drift assessed this run — **the run could not
+complete**. All five live sources this skill depends on were unreachable
+from this environment due to network egress policy, so no facts could be
+verified against the reference files. No files were edited and the
+snapshot was **not** updated (it still reflects the 2026-07-07 unverified
+baseline from the previous run).
+
+## What happened
+
+This session's outbound network egress is allow-listed, and none of the
+docs-watch sources are on the allow-list. Every fetch attempt returned
+`403 Forbidden` at the egress proxy (confirmed via
+`$HTTPS_PROXY/__agentproxy/status`, which logs these as
+`connect_rejected` / "gateway answered 403 to CONNECT"):
+
+| Host | Result |
+|---|---|
+| `docs.celo.org` | 403 (proxy denial) |
+| `api.llama.fi` | 403 (proxy denial) |
+| `www.celopg.eco` | 403 (proxy denial) |
+
+For comparison, `raw.githubusercontent.com` returned `200` in the same
+session, confirming this is a targeted policy allow-list (GitHub-related
+hosts reachable; general web, including docs.celo.org/DefiLlama/celopg.eco,
+is not) rather than a total outage. Per the proxy's own guidance ("do not
+retry or route around it — report the blocked host"), no workaround was
+attempted.
+
+## Per-source status
+
+1. **Docs sitemap** (`docs-map.md`) — not checked. Source unreachable.
+2. **Contract addresses** (`contracts.md`) — not checked. Source unreachable.
+3. **Network info** (`network-info.md`) — not checked. Source unreachable.
+4. **Ecosystem / TVL** (`ecosystem.md`) — not checked. Source unreachable.
+5. **Grant programs** (`grants-funding.md`) — not checked. Source unreachable.
+
+No `reference update` or `needs review` classifications were possible this
+run since no live data was retrieved to diff against.
+
+## Recommendation
+
+The environment this scheduled routine runs in needs `docs.celo.org`,
+`api.llama.fi`, and `www.celopg.eco` added to its egress allow-list for
+this skill to function. Until then, this weekly check will keep coming up
+empty. Flagging to the user so the environment's network policy can be
+adjusted (Claude Code on the web → environment settings).

--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -1,0 +1,60 @@
+# docs-watch snapshot — facts we depend on
+
+Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
+live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
+snapshot as unverified against live sources until the first real run).
+
+## 1. Docs sitemap (`docs-map.md`)
+
+- Source: `docs.celo.org/llms.txt`
+- Sections tracked: Getting Started, Build on MiniPay, Build with AI
+  (incl. x402, 8004, MCP), Build with Ecosystem, Protocol, Tooling (Dev
+  Environments, Libraries & SDKs, Contracts, Infrastructure, Wallets, Other),
+  Managing Assets, Infrastructure Partners, Hardforks & Notices (Jello,
+  Jovian, Isthmus, Ice Cream/EigenDA v2)
+- ~150 pages total as of last count
+
+## 2. Contract addresses (`contracts.md`)
+
+- Source: `docs.celo.org/tooling/contracts/*`
+- Core protocol contracts (mainnet): 20 tracked (Registry, Accounts,
+  CeloToken/GoldToken, Election, EpochManager, EpochRewards, Escrow,
+  FederatedAttestations, FeeCurrencyDirectory, FeeHandler, Freezer,
+  Governance, GovernanceSlasher, LockedCelo/LockedGold,
+  MentoFeeHandlerSeller, OdisPayments, Reserve, ScoreManager, SortedOracles,
+  Validators, UniswapFeeHandlerSeller, Attestations)
+- Registry address: `0x000000000000000000000000000000000000ce10`
+- Mento stablecoins tracked: 15+ (USDm, EURm, BRLm, XOFm, KESm, NGNm, COPm,
+  GBPm, CHFm, JPYm, AUDm, CADm, GHSm, PHPm, ...)
+
+## 3. Network info (`network-info.md`)
+
+- Source: `docs.celo.org/build-on-celo/network-overview`
+- Mainnet chain ID: `42220`; Sepolia testnet chain ID: `11142220`
+- Public RPC: `https://forno.celo.org`
+- L2 stack: OP Stack + EigenDA v2 DA + ZK fault proofs (Succinct SP1, Jello
+  hardfork); L1→L2 migration block 31,056,500 (2025-03-26)
+- Fee-currency (gas abstraction) tokens: USDm, EURm (token == adapter),
+  USDC, USDT (adapter ≠ token address — 6→18 decimal adapters)
+- `FeeCurrencyDirectory`: `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276`
+- `eth_getLogs` range limit: ~50,000 blocks
+
+## 4. Ecosystem / TVL (`ecosystem.md`)
+
+- Source: DefiLlama (`api.llama.fi/protocols`, `/v2/chains`), docs.celo.org,
+  celo.org/ecosystem
+- Categories tracked: DEXes (7), Lending (3), Yield/Liquidity mgmt (5),
+  Stablecoins (2), Liquid Staking (1), Derivatives (1), RWA (6),
+  Payments/Streaming (1), plus Governance section
+- Notable recent additions already reflected: Uniswap V4 (Oct 2025), Carbon
+  DeFi (canonical name — not "Carbon"), Mento V3
+
+## 5. Grant programs (`grants-funding.md`)
+
+- Source: `www.celopg.eco/programs` (status changes frequently — this file
+  is explicitly a stale-prone cache per its own header)
+- Currently-Live programs tracked: Prezenti Anchor Round (through
+  2026-06-30), GoodBuilders Season 3 (through 2026-05-18), Celo Builder Fund
+  (year-round through 2026-12-31)
+- Note: Prezenti and GoodBuilders end dates are in the past relative to a
+  post-2026-06-30 run — check status flip to "Past" on the next run.

--- a/skills/celopedia-skill/references/contracts.md
+++ b/skills/celopedia-skill/references/contracts.md
@@ -69,6 +69,19 @@ All addresses verified from official Celo documentation. **Do not guess addresse
 | Wrapped Ether | WETH | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` |
 | CELO (ERC-20) | CELO | `0x471EcE3750Da237f93B8E339c536989b8978a438` |
 
+### Ripio Stablecoins
+
+Ripio-issued wrapped Latin American fiat stablecoins.
+
+| Token | Symbol | Address |
+|-------|--------|---------|
+| Wrapped Argentine Peso | wARS | `0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D` |
+| Wrapped Brazilian Real | wBRL | `0xD76f5Faf6888e24D9F04Bf92a0c8B921FE4390e0` |
+| Wrapped Mexican Peso | wMXN | `0x337E7456B420bD3481e7FA61fA9850343d610d34` |
+| Wrapped Colombian Peso | wCOP | `0x8a1D45e102e886510e891d2Ec656a708991e2D76` |
+| Wrapped Peruvian Sol | wPEN | `0x4F34c8b3b5FB6D98Da888F0feA543d4d9C9F2eBE` |
+| Wrapped Chilean Peso | wCLP | `0x61D450a098b6a7f69fC4b98CE68198fe59768651` |
+
 ---
 
 ## L1 Contracts on Ethereum (Mainnet)

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -122,6 +122,19 @@ Celo is known as the "Home of Stablecoins" with 15+ Mento local-currency stablec
 | USDC (Circle) | USDC |
 | Tether USD | USDT |
 
+### Ripio Stablecoins
+
+Ripio-issued wrapped Latin American fiat (see contracts.md for addresses).
+
+| Currency | Symbol | Region |
+|----------|--------|--------|
+| Argentine Peso | wARS | Argentina |
+| Brazilian Real | wBRL | Brazil |
+| Mexican Peso | wMXN | Mexico |
+| Colombian Peso | wCOP | Colombia |
+| Peruvian Sol | wPEN | Peru |
+| Chilean Peso | wCLP | Chile |
+
 ---
 
 ## Infrastructure


### PR DESCRIPTION
Adds Ripio's six wrapped Latin American fiat stablecoins (wARS, wBRL, wMXN, wCOP, wPEN, wCLP) to the two registries that list the full stablecoin set: the mainnet address table in `contracts.md` and the stablecoin directory in `ecosystem.md`. Each token gets its own "Ripio Stablecoins" subsection, following existing convention — bare EIP-55 checksummed addresses with no per-token links. The functional-subset lists (MiniPay, x402, fee-currency tables, Aave, FPMM pools) were intentionally left untouched since Ripio tokens don't qualify for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)