### PR TITLE
feat(contracts): add Ripio LatAm stablecoins to registries

### DIFF
--- a/skills/celopedia-skill/references/contracts.md
+++ b/skills/celopedia-skill/references/contracts.md
@@ -77,6 +77,12 @@ All addresses verified from official Celo documentation. **Do not guess addresse
 | BRLA Digital | BRLA | `0xFECB3F7c54E2CAAE9dC6Ac9060A822D47E053760` |
 | Minteo Colombian Peso | COPM | `0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606` |
 | GoodDollar | G$ | `0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A` |
+| Ripio Argentine Peso | wARS | `0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D` |
+| Ripio Brazilian Real | wBRL | `0xD76f5Faf6888e24D9F04Bf92a0c8B921FE4390e0` |
+| Ripio Mexican Peso | wMXN | `0x337E7456B420bD3481e7FA61fA9850343d610d34` |
+| Ripio Colombian Peso | wCOP | `0x8a1D45e102e886510e891d2Ec656a708991e2D76` |
+| Ripio Peruvian Sol | wPEN | `0x4F34c8b3b5FB6D98Da888F0feA543d4d9C9F2eBE` |
+| Ripio Chilean Peso | wCLP | `0x61D450a098b6a7f69fC4b98CE68198fe59768651` |
 | Wrapped Ether | WETH | `0xD221812de1BD094f35587EE8E174B07B6167D9Af` |
 | CELO (ERC-20) | CELO | `0x471EcE3750Da237f93B8E339c536989b8978a438` |
 

--- a/skills/celopedia-skill/references/ecosystem.md
+++ b/skills/celopedia-skill/references/ecosystem.md
@@ -136,6 +136,12 @@ Sourced from the official list (https://docs.celo.org/build-on-celo/build-with-l
 | BRLA Digital | BRLA | BRLA | `0xFECB3F7c54E2CAAE9dC6Ac9060A822D47E053760` |
 | Minteo Colombian Peso | COPM | Minteo | `0xC92E8Fc2947E32F2B574CCA9F2F12097A71d5606` |
 | GoodDollar | G$ | GoodDollar | `0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A` |
+| Wrapped Argentine Peso | wARS | Ripio | `0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D` |
+| Wrapped Brazilian Real | wBRL | Ripio | `0xD76f5Faf6888e24D9F04Bf92a0c8B921FE4390e0` |
+| Wrapped Mexican Peso | wMXN | Ripio | `0x337E7456B420bD3481e7FA61fA9850343d610d34` |
+| Wrapped Colombian Peso | wCOP | Ripio | `0x8a1D45e102e886510e891d2Ec656a708991e2D76` |
+| Wrapped Peruvian Sol | wPEN | Ripio | `0x4F34c8b3b5FB6D98Da888F0feA543d4d9C9F2eBE` |
+| Wrapped Chilean Peso | wCLP | Ripio | `0x61D450a098b6a7f69fC4b98CE68198fe59768651` |
 
 > ⚠️ **Ticker collisions** (match on address, not symbol): Mountain Protocol's **USDM** (yield-bearing, US-Treasury backed, `0x59D9…508C`) ≠ Celo's **USDm** (cUSD, the Mento dollar). Minteo's **COPM** (`0xC92E…`) ≠ Mento's **COPm**.
 


### PR DESCRIPTION
Adds Ripio's six wrapped Latin American fiat stablecoins (wARS, wBRL, wMXN, wCOP, wPEN, wCLP) to the external / third-party stablecoin tables in `contracts.md` and `ecosystem.md`. They're added as flat rows alongside the other third-party issuers (BRLA, Minteo, VNX, Angle…), matching the existing convention — EIP-55 checksummed addresses, issuer listed as Ripio in the ecosystem.md table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)