### PR TITLE
feat(skill): v2.6.0 — hosted Celo x402 facilitator (x402.celo.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Deep protocol reference for Uniswap V3/V4, Aave V3, Carbon DeFi, Morpho Blue, Me
 Build Mini Apps for MiniPay (16M+ wallets). Wallet detection, auto-connect patterns, stablecoin payments, phone number resolution, testing with ngrok, and ready-to-use code templates. Includes the official submission checklist (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA).
 
 ### AI Agent Builder
-ERC-8004 (Agent Trust Protocol), Self Agent ID (proof-of-human), the Celo Agent Visa program, x402 (HTTP micropayments), Celo MCP Server, and the Agent Skills specification. Build onchain agents that transact autonomously on Celo.
+ERC-8004 (Agent Trust Protocol), Self Agent ID (proof-of-human), the Celo Agent Visa program, x402 (HTTP micropayments, with Celo's hosted facilitator at [x402.celo.org](https://x402.celo.org)), Celo MCP Server, and the Agent Skills specification. Build onchain agents that transact autonomously on Celo.
 
 ### Security & Audit Readiness
 Celo-specific security patterns (CELO duality, CIP-64 fee abstraction, Aave aToken drift, Mento circuit breakers, post-L2 epoch effects). Chain-agnostic Solidity audits defer to [pashov/skills](https://github.com/pashov/skills).
@@ -137,7 +137,7 @@ The skill lives at `skills/celopedia-skill/` and is organized into topic-grouped
 | File | What |
 |------|------|
 | [`governance.md`](skills/celopedia-skill/references/governance.md) | On-chain governance reference |
-| [`ai-agents.md`](skills/celopedia-skill/references/ai-agents.md) | ERC-8004, x402, MCP, Agent Skills |
+| [`ai-agents.md`](skills/celopedia-skill/references/ai-agents.md) | ERC-8004, x402 + hosted Celo facilitator, MCP, Agent Skills |
 | [`security-patterns.md`](skills/celopedia-skill/references/security-patterns.md) | Celo-specific security risks (pairs with [pashov/skills](https://github.com/pashov/skills)) |
 
 ## Contributing

--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.5.0"
+  version: "2.6.0"
 ---
 
 # Celopedia Skill
@@ -101,7 +101,7 @@ Build AI agents that transact on Celo.
 - **ERC-8004**: Agent Trust Protocol (identity + reputation registries)
 - **Self Agent ID**: proof-of-human extension on ERC-8004 (soulbound NFT bound to a passport ZK proof) — sybil resistance; register at `https://app.ai.self.xyz`. See `self-agent-id.md`.
 - **Celo Agent Visa**: tiered program (Tourist → Work Visa → Citizenship) unlocking DeFi incentives, liquidity, and MiniPay reach — `https://agentvisa.self.xyz/agents/visa`
-- **x402**: HTTP-native micropayments with stablecoins
+- **x402**: HTTP-native micropayments with stablecoins — Celo runs a **hosted facilitator** at `https://x402.celo.org` (dashboard/API keys; mainnet API `api.x402.celo.org`, testnet `api.x402.sepolia.celo.org`; sponsored gas, USDC/USDT via EIP-3009). Agent-readable integration guide: `https://x402.celo.org/SKILL.md` — fetch it before writing integration code. Details: `ai-agents.md` → _Hosted Celo Facilitator_
 - **Celo MCP Server**: Query blockchain data from coding assistants
 - **Agent Skills**: Modular skill system for AI coding agents
 - **Onchain Agents Hackathon** (May 22 – Jun 15, 2026, $5K in CELO): build payment-native agents; submit via the **Celo Builders skill** (`npx skills add https://celobuilders.xyz`) — `https://bit.ly/OnchainAgentsHackathon`
@@ -195,6 +195,7 @@ Start with `growth-diagnostic.md` — the 6-question diagnostic routes the build
 | What Mini Apps are live / discovery ideas | Check `minipay-live-apps.md` (snapshot; country availability varies) |
 | ODIS / phone lookup / SocialConnect | Check `odis-socialconnect.md`, `minipay-guide.md`, `contracts.md` |
 | AI agent building | Check `ai-agents.md` |
+| x402 / pay-per-use API / paid endpoints | Check `ai-agents.md` → x402; hosted facilitator guide: `https://x402.celo.org/SKILL.md` |
 | Security / audit prep | Check `security-patterns.md` (Celo-specific); defer general Solidity audits to `pashov/skills` |
 | Grants / funding | Check `grants-funding.md` |
 | Documentation | Check `docs-map.md` |

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -208,7 +208,7 @@ The thirdweb flow below is an **alternative** that uses thirdweb's own facilitat
 | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | 6 |
 | USDm | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | 18 |
 
-> ⚠️ USDm implements EIP-2612 `permit` only, **not** EIP-3009 — it does not work with the hosted Celo facilitator above. Check your facilitator's supported schemes before pricing in USDm.
+> ⚠️ **USDm caveat.** USDm (Mento `StableTokenV3`) implements EIP-2612 `permit` only, **not** EIP-3009 `transferWithAuthorization` (verified on-chain) — so it does **not** work with the hosted Celo facilitator, whose engine currently implements only the EIP-3009 transfer method. The x402 `exact` EVM spec also defines Permit2 / EIP-2612 fallback methods, and facilitators that implement them (e.g. thirdweb accepts "ERC-2612 permit" tokens) can settle USDm. Rule: **match the token to your facilitator's supported transfer methods** — for the hosted Celo facilitator that means USDC or USDT.
 
 ### Server Implementation (Next.js)
 

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -198,7 +198,7 @@ Celo runs an official hosted x402 facilitator, so builders don't need to run the
 - **Token support (EIP-3009)**: USDC (mainnet + Sepolia) and USDT (mainnet). **USDm is NOT supported by this facilitator** — Mento `StableTokenV2` implements only EIP-2612 `permit`, not EIP-3009. USDT's EIP-712 domain is `name: "Tether USD", version: "1"` (its `version()` method reverts).
 - Test on Celo Sepolia first — testnet USDC from https://faucet.circle.com (buyers need no testnet CELO; gas is sponsored).
 
-The thirdweb flow below is an **alternative** that uses thirdweb's own facilitator instead.
+The thirdweb flow below is an **alternative** that uses thirdweb's own facilitator instead — and it is the path to take when you want to charge in **USDm or other Mento local stablecoins**, which the hosted facilitator cannot settle (see the USDm caveat below).
 
 ### Supported Tokens on Celo
 
@@ -208,7 +208,7 @@ The thirdweb flow below is an **alternative** that uses thirdweb's own facilitat
 | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | 6 |
 | USDm | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | 18 |
 
-> ⚠️ **USDm caveat.** USDm (Mento `StableTokenV3`) implements EIP-2612 `permit` only, **not** EIP-3009 `transferWithAuthorization` (verified on-chain) — so it does **not** work with the hosted Celo facilitator, whose engine currently implements only the EIP-3009 transfer method. The x402 `exact` EVM spec also defines Permit2 / EIP-2612 fallback methods, and facilitators that implement them (e.g. thirdweb accepts "ERC-2612 permit" tokens) can settle USDm. Rule: **match the token to your facilitator's supported transfer methods** — for the hosted Celo facilitator that means USDC or USDT.
+> ⚠️ **USDm / Mento local stablecoin caveat.** USDm — and the rest of the Mento family (EURm, BRLm, KESm, …; all `StableTokenV2`/`V3` implementations, verified on-chain) — implements EIP-2612 `permit` only, **not** EIP-3009 `transferWithAuthorization`. So Mento stablecoins do **not** work with the hosted Celo facilitator, whose engine currently implements only the EIP-3009 transfer method. The x402 `exact` EVM spec also defines Permit2 / EIP-2612 fallback methods, and facilitators that implement them (e.g. **thirdweb**, which accepts "ERC-2612 permit" tokens) can settle USDm and the local stablecoins. This matters for agents that price or settle in local currencies — e.g. FX and trading agents paying per-request in KESm or BRLm — which should use the thirdweb flow. Rule: **match the token to your facilitator's supported transfer methods** — hosted Celo facilitator → USDC/USDT; thirdweb → also USDm + Mento locals.
 
 ### Server Implementation (Next.js)
 

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -173,6 +173,33 @@ Protocol enabling pay-per-request APIs using HTTP 402 status code and stablecoin
 5. Server verifies payment via facilitator
 6. Server settles on-chain and delivers response
 
+### Hosted Celo Facilitator (x402.celo.org) — default choice
+
+Celo runs an official hosted x402 facilitator, so builders don't need to run their own verify/settle infrastructure. The facilitator **sponsors settlement gas** (buyers need no CELO) and **never custodies funds** — EIP-3009 `transferWithAuthorization` moves stablecoins buyer → seller directly inside the token contract.
+
+| What | URL |
+|------|-----|
+| Dashboard (API key, credits, top-ups) | https://x402.celo.org |
+| Mainnet facilitator API (`eip155:42220`) | https://api.x402.celo.org |
+| Testnet facilitator API (`eip155:11142220`) | https://api.x402.sepolia.celo.org |
+| **Full integration guide (agent-readable skill)** | https://x402.celo.org/SKILL.md |
+| Live config (treasury, price, tokens, free credits) | https://x402.celo.org/api/config |
+
+**Always fetch `https://x402.celo.org/SKILL.md` before writing integration code** — it carries the current, settlement-verified seller (`@x402/hono` / `@x402/express`) and buyer (`@x402/fetch`) code for this facilitator.
+
+**Metering model** (snapshot — confirm via `/api/config`): connect a wallet on the dashboard and sign a message (no gas) → API key with free starter credits (500 mainnet / 1,000 testnet). Each on-chain `/settle` costs 1 credit (flat $0.001, topped up with USDC on the dashboard). `/verify` and `/supported` are free and need no key.
+
+**Integration gotchas for this facilitator:**
+
+- Use the **v2 scoped `@x402/*` packages** (`@x402/hono` or `@x402/express` + `@x402/core` + `@x402/evm`; buyer: `@x402/fetch`). The legacy `x402-express` / `x402-fetch` packages have no Celo entry in their network enum and will not work.
+- Celo is **not in the x402 packages' default-asset table** — a bare `price: "$0.01"` type-checks but throws at request time. Always pass the explicit price object: `{ amount: "10000", asset: USDC_ADDRESS, extra: { name: "USDC", version: "2" } }` (string amounts in 6-decimal base units; `$0.01 = "10000"`).
+- Attach the API key with `HTTPFacilitatorClient({ createAuthHeaders })` as `X-API-Key` — it goes only to the facilitator, never to buyers or the browser.
+- `payTo` is the **seller's own receiving wallet** — not the facilitator, not the buyer.
+- **Token support (EIP-3009)**: USDC (mainnet + Sepolia) and USDT (mainnet). **USDm is NOT supported by this facilitator** — Mento `StableTokenV2` implements only EIP-2612 `permit`, not EIP-3009. USDT's EIP-712 domain is `name: "Tether USD", version: "1"` (its `version()` method reverts).
+- Test on Celo Sepolia first — testnet USDC from https://faucet.circle.com (buyers need no testnet CELO; gas is sponsored).
+
+The thirdweb flow below is an **alternative** that uses thirdweb's own facilitator instead.
+
 ### Supported Tokens on Celo
 
 | Token | Address | Decimals |
@@ -180,6 +207,8 @@ Protocol enabling pay-per-request APIs using HTTP 402 status code and stablecoin
 | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | 6 |
 | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | 6 |
 | USDm | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | 18 |
+
+> ⚠️ USDm implements EIP-2612 `permit` only, **not** EIP-3009 — it does not work with the hosted Celo facilitator above. Check your facilitator's supported schemes before pricing in USDm.
 
 ### Server Implementation (Next.js)
 


### PR DESCRIPTION
Follow-up to #28 — these two commits were pushed after that PR merged.

Adds a new _Hosted Celo Facilitator_ section to `ai-agents.md` documenting [x402.celo.org](https://x402.celo.org): dashboard/API-key flow, mainnet (`api.x402.celo.org`) and Sepolia (`api.x402.sepolia.celo.org`) endpoints, the metering model, the agent-readable integration guide at `x402.celo.org/SKILL.md`, and the key gotchas — v2 `@x402/*` packages only, explicit price object (Celo isn't in the packages' default-asset table), `X-API-Key` wiring, and EIP-3009 token support (USDC/USDT). Wired into the SKILL.md AI Agent Builder section, the query-routing table, and the README; version bumps 2.5.0 → 2.6.0.

Also refines the USDm caveat with on-chain-verified nuance: USDm (StableTokenV3) implements EIP-2612 permit only, not EIP-3009, so it doesn't work with the hosted facilitator — but the x402 exact-EVM spec defines Permit2/EIP-2612 fallbacks that other facilitators (e.g. thirdweb) implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)