### PR TITLE
docs-watch: blocked — 2026-07-13

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-07-13 — BLOCKED (docs.celo.org, api.llama.fi, celopg.eco)
+— updated by every run, including blocked ones, per `SKILL.md` step 6. A
+`BLOCKED` value here means the most recent run couldn't reach one or more
+sources; check the linked PR for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Summary

This week's docs-watch run could not check any of the 5 live sources — all outbound requests were rejected by this session's network egress policy (403 on CONNECT), not by the upstream services themselves. No drift could be assessed. This PR only records the attempt, per the skill's "Blocked" procedure; no reference files were edited.

## Sources attempted

| # | Source | Host | Result |
|---|--------|------|--------|
| 1 | Docs sitemap (`docs.celo.org/llms.txt`) | `docs.celo.org` | ❌ Blocked — 403 policy denial on CONNECT |
| 2 | Contract addresses (`docs.celo.org/tooling/contracts/*`) | `docs.celo.org` | ❌ Blocked — same host as #1, not attempted separately |
| 3 | Network info (`docs.celo.org/build-on-celo/network-overview`) | `docs.celo.org` | ❌ Blocked — same host as #1, not attempted separately |
| 4 | DefiLlama protocols (`api.llama.fi/protocols`) | `api.llama.fi` | ❌ Blocked — 403 policy denial on CONNECT |
| 5 | Grant programs (`www.celopg.eco/programs`) | `celopg.eco` | ❌ Blocked — 403 policy denial (WebFetch) |

Verified via the environment's agent proxy status endpoint, which logged `connect_rejected` / "gateway answered 403 to CONNECT (policy denial or upstream failure)" for `docs.celo.org:443` and `api.llama.fi:443`, and WebFetch returned a 403 for `celopg.eco`.

## What changed

Only `.claude/skills/docs-watch/snapshot.md`'s top-of-file "Last attempt" line, per step 6 of `SKILL.md`:

```
Last attempt: 2026-07-13 — BLOCKED (docs.celo.org, api.llama.fi, celopg.eco)
```

No reference files under `skills/celopedia-skill/references/` were touched, and no version bump was made — nothing was actually re-verified this run.

## Needs review

The real fix here isn't in this PR — it's the network egress policy for this environment/session needing `docs.celo.org`, `api.llama.fi`, and `www.celopg.eco` allow-listed so future docs-watch runs can actually reach these sources. This PR is informational; merging just records the attempt, and closing without merging is equally fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Swca9DeKw3FpiCKftv5wy)_