### PR TITLE
feat(skill): separate MiniPay channel fit from demand evidence

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -8,7 +8,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.6.0"
+  version: "2.7.0"
 ---
 
 # Celopedia Skill
@@ -90,7 +90,7 @@ Build Mini Apps for MiniPay — Celo's stablecoin wallet with 16M+ users.
 - Scaffold options: **Celo Composer** (batteries-included) or **raw Next.js** (see `minipay-scaffold-from-scratch.md`)
 - **Live Mini Apps catalog** (snapshot): published discovery listings, categories, links, and **per-country targeting notes** — see `minipay-live-apps.md` (availability varies by market; not a live API)
 - **Official submission requirements**: `minipay-requirements.md` — listing is a **two-stage process**. Stage 1 is the public **intake form** at `https://minipay.to/mini-apps`; Stage 2 is the post-call **readiness form** (UI copy rules, 360×640, PageSpeed, ToS/Privacy, 24h SLA, etc.). Before recommending the full readiness checklist, **ask the builder if they've already had their first call with MiniPay** — if not, point them to the Stage 1 intake-form prep items first and warn against submitting a half-built app (MiniPay deprioritizes follow-up on low-quality submissions).
-- **App Fit & Priority Framework**: before building, use `minipay-app-fit.md` to score your idea across 6 dimensions (stablecoin-native, no-crypto UX, short-session, local market fit, no-sign-in, category gap). Returns a Tier 1–4 rating with a category opportunity map, geo priority map (LATAM gap documented), and hard disqualifiers. Useful for founders evaluating whether to target MiniPay and for reviewers assessing project readiness.
+- **App Fit & Priority Framework**: before building, use `minipay-app-fit.md`. It separates **MiniPay channel fit** (a 5-dimension scorecard: stablecoin-native, short-session, local market fit, no `personal_sign`, catalog whitespace) from **demand evidence** and **source of funds** — evaluated separately so a high channel-fit score never reads as validated demand on its own. Returns a channel-fit + demand recommendation (build now / validate first / blocked by funding rail / wrong channel), a category opportunity map, and hard disqualifiers. Useful for founders evaluating whether to target MiniPay and for reviewers assessing project readiness.
 
 **References**: `minipay-guide.md`, `minipay-templates.md`, `minipay-scaffold-from-scratch.md`, `odis-socialconnect.md`, `minipay-live-apps.md`, `minipay-requirements.md`, `minipay-docs-map.md` (page-by-page index of `docs.minipay.xyz`), `minipay-app-fit.md`, `minipay-performance.md` (measure real-user load speed with PostHog Web Vitals + optimization playbook to hit the 90+ PageSpeed listing requirement)
 

--- a/skills/celopedia-skill/references/minipay-app-fit.md
+++ b/skills/celopedia-skill/references/minipay-app-fit.md
@@ -9,6 +9,18 @@
 > **Data sources:** `minipay-live-apps.md` (catalog snapshot) · `minipay-requirements.md`
 > (official submission checklist) · `minipay-guide.md` (technical constraints).
 
+> ⚠️ **Read this first — two questions, not one.** A high score below means your idea has strong
+> **MiniPay channel fit** (it would work well *inside* MiniPay). It does **not** mean the idea has
+> validated **demand**. These are independent axes:
+>
+> - **MiniPay Channel Fit** — would it work well in MiniPay's UX, tokens, and constraints? (§2 scorecard)
+> - **Demand Evidence** — is there evidence people actually want this, and a path to the first dollar? (§3)
+>
+> An idea can be a perfect channel fit and still fail because nobody needed it. The most common
+> failure mode is building on channel fit alone, then discovering after launch that the market never
+> existed (e.g. a local-stablecoin app that MiniPay does not prioritise, or a "buy X" app in a market
+> where no rail funds the wallet). **Score channel fit, then evidence demand, then decide.**
+
 ---
 
 ## 0. Understand Your Builder Profile First
@@ -59,9 +71,10 @@ Before scoring your idea, know the person on the other end of the screen.
 
 ---
 
-## 2. App Fit Scorecard
+## 2. Channel-Fit Scorecard
 
-Score your idea on 5 dimensions (0–2 each). Total out of 10.
+Score your idea on 5 dimensions (0–2 each). Total out of 10. **This measures MiniPay channel fit only** —
+whether the idea works *inside* MiniPay. It says nothing about demand; that is §3.
 
 ### A. Stablecoin-native
 Does the core value of your app involve sending, receiving, saving, or earning USDm / USDT / USDC?
@@ -131,7 +144,7 @@ MiniPay does not support `personal_sign` or `eth_signTypedData`. Can your app wo
 
 ---
 
-### E. Category gap in current catalog
+### E. Catalog whitespace
 Is your category underserved in the MiniPay Discovery catalog right now?
 
 | Score | What it means |
@@ -141,25 +154,83 @@ Is your category underserved in the MiniPay Discovery catalog right now?
 | **0** | Highly competitive category with no clear differentiation angle |
 
 > See `minipay-live-apps.md` for the current catalog snapshot with per-country availability data.
+>
+> ⚠️ **Whitespace is not demand.** An empty category can mean an untapped opportunity **or** that no
+> one wants it there. Zero competitors is ambiguous on its own — score it here as *channel* signal, then
+> confirm real demand separately in §3 before treating it as a reason to build.
+>
+> **A live listing proves availability, not traction or problem resolution.** The catalog snapshot
+> shows what exists, not what works, retains users, or has solved the problem — never infer demand from
+> presence in the catalog.
 
 ---
 
-## 3. Priority Tiers
+## 3. Demand Evidence & Source of Funds (evaluate separately — do not add to the §2 score)
 
-Use your total score to understand what to do next.
+Two independent checks. Neither adds to your channel-fit score; **either one can veto a "build now."**
+Channel fit tells you the idea *fits the channel*; these tell you whether it's worth building at all.
 
-| Total Score | Priority | What to do |
-|-------------|----------|------------|
-| **8–10** | 🟢 **Tier 1 — Build now** | Strong fit. MiniPay Discovery should be your primary distribution target. Get a Celo team review before submitting. |
-| **5–7** | 🟡 **Tier 2 — Build, fix the gaps** | Good fit but one or two dimensions are weak. Find your lowest score, fix that specific gap, then re-evaluate. |
-| **3–4** | 🟠 **Tier 3 — Validate before committing** | Partial fit. Test with real users via ngrok before building further. Consider Proof of Ship to get community feedback first. |
-| **0–2** | 🔴 **Tier 4 — Wrong channel for now** | Structural mismatch with MiniPay. Pivot the concept or choose a different channel. Proof of Ship is a good place to explore alternatives. |
+### Demand evidence
+Rate the strongest evidence you actually have that people want this. Higher is better.
+
+| Level | What it means |
+|-------|---------------|
+| **MiniPay-requested** | MiniPay / Celo has explicitly asked for this (official wishlist, partner ask, team callout) |
+| **Observed in MiniPay** | Users already do a workaround inside MiniPay, or an existing listing shows pull for this need |
+| **Locally validated** | You have talked to real target-market users who have this problem and want a fix (interviews, waitlist, pilot) |
+| **External analogy only** | It worked in another ecosystem/market; no direct evidence in the MiniPay market yet |
+| **Speculative** | "It should work" — no evidence beyond intuition |
+
+> **External analogy only** or **Speculative** ⇒ *validate before building*, no matter how high your
+> channel-fit score is. "It worked on [other chain/market]" is a hypothesis, not demand. Run the
+> cheapest test that could invalidate it before writing an MVP.
+
+### Source of funds — who puts the first dollar in the wallet, and why?
+Every savings, payments, investment, remittance, or commerce idea dies if no real rail funds the wallet
+in your target market. Name the source explicitly.
+
+| Source | You must verify |
+|--------|-----------------|
+| Remittance | The corridor + rail actually reaches MiniPay wallets in that market |
+| Salary / freelance payout | A payer exists who will pay into the wallet |
+| Merchant revenue | Merchants accept and settle in stablecoins there |
+| Rewards / gaming | The reward budget is real and sustainable, not a one-off incentive |
+| Stablecoins the user already holds | The user already has a funded balance (rare for new users) |
+| Manual on-ramp | ⚠️ The on-ramp rail actually works in the target market — the most common silent failure |
+| Ecosystem incentives | Funding ends when the program ends — not a durable source |
+
+> **If the answer is "the user funds it manually," stop and check the rail.** A "buy X" or savings app
+> is only as real as the cheapest way its users get money into the wallet. Confirm the specific
+> on-ramp/rail works in the specific country **before** building — see `stablecoin-orchestration.md`
+> for which rails are live vs. Beta per market (e.g. COP via Bre-B/PSE/ACH is still Beta).
 
 ---
 
-## 4. Category Opportunity Map
+## 4. Recommendation — combine channel fit with demand
 
-Current catalog density from `minipay-live-apps.md` (snapshot — verify before using):
+Read your §2 total against your §3 demand evidence. **Do not** collapse this into a single number.
+
+| §2 channel fit | §3 demand evidence | Recommendation |
+|----------------|--------------------|----------------|
+| 8–10 | Locally validated or stronger, funded source | 🟢 **Build now** — strong channel fit *and* evidenced demand. Get a Celo team review before submitting. |
+| 8–10 | External analogy / Speculative | 🟡 **Strong MiniPay channel fit — validate demand first.** Run the cheapest invalidating test and confirm the funding rail before building. |
+| 5–7 | any | 🟡 **Build, fix the gaps.** Find your lowest §2 score, fix it; in parallel raise demand evidence. |
+| any | no viable source of funds | 🟠 **Blocked by funding rail.** No real way to get the first dollar into the wallet in this market — fix the rail question or pick another market before building. |
+| 3–4 | any | 🟠 **Validate before committing.** Test with real users via ngrok; consider Proof of Ship for feedback first. |
+| 0–2 | any | 🔴 **Wrong channel for now.** Structural mismatch with MiniPay. Pivot the concept or choose a different channel. |
+
+> The old "score → single tier" table conflated *fits the channel* with *worth building*. High channel
+> fit with speculative demand is **not** a green light — it's a signal to validate cheaply first.
+
+---
+
+## 5. Category Opportunity Map
+
+Current catalog density from `minipay-live-apps.md` (snapshot — verify before using).
+
+> ⚠️ **"Opportunity" here means catalog whitespace, not measured demand.** A category marked 🟢 High is
+> *under-covered*, which is a channel signal — pair it with §3 demand evidence before treating it as a
+> reason to build. Low coverage can equally mean low demand.
 
 | Category | Apps live | Opportunity | Notes |
 |----------|-----------|-------------|-------|
@@ -177,7 +248,7 @@ Current catalog density from `minipay-live-apps.md` (snapshot — verify before 
 
 ---
 
-## 5. Things to Fix Before Submitting
+## 6. Things to Fix Before Submitting
 
 These are technical constraints that need to be addressed before your app can function correctly in MiniPay. All of them are fixable — address them during development.
 
@@ -191,7 +262,7 @@ These are technical constraints that need to be addressed before your app can fu
 
 ---
 
-## 6. Pre-fit Checklist (run before scoring)
+## 7. Pre-fit Checklist (run before scoring)
 
 Before applying the scorecard, answer these questions. A single "No" on items 1–3 is an immediate Tier 4:
 
@@ -201,9 +272,10 @@ Before applying the scorecard, answer these questions. A single "No" on items 1�
 
 ---
 
-## 7. Example Score — Reference
+## 8. Example Score — Reference
 
 The table below shows a worked example for orientation. Replace with your own app's values.
+Note the two separate axes: the scorecard measures **channel fit**; demand and funding are read alongside it.
 
 | Dimension | Score | Rationale |
 |-----------|-------|-----------|
@@ -211,8 +283,19 @@ The table below shows a worked example for orientation. Replace with your own ap
 | B. Short-session | 2 | Core action (3 taps): choose → confirm → done |
 | C. Local market fit | 2 | Directly solves a documented pain point in a specific primary market |
 | D. No `personal_sign` | 2 | Wallet address = identity; no `personal_sign` anywhere |
-| E. Category gap | 2 | Category has zero or one Celo-native apps |
-| **Total** | **10 / 10** | **🟢 Tier 1 — Build now** |
+| E. Catalog whitespace | 2 | Category has zero or one Celo-native apps |
+| **Channel-fit total** | **10 / 10** | Strong MiniPay channel fit |
+
+Now read it against §3 (evaluated separately, **not** added to the 10):
+
+| Separate check | Value | So what |
+|----------------|-------|---------|
+| Demand evidence | Locally validated (20 target-market user interviews + waitlist) | Evidence is real, not analogy |
+| Source of funds | Salary payout — a documented payer pays into the wallet | The first dollar has a verified rail |
+| **Recommendation** | — | **🟢 Build now** (§4) — strong channel fit *and* evidenced, funded demand |
+
+> Had demand been *External analogy only* or the funding source *manual on-ramp with no verified rail*,
+> the same 10/10 channel fit would read **🟡 validate first** or **🟠 blocked by funding rail** — not build now.
 
 ---
 


### PR DESCRIPTION
## What

Separate **MiniPay channel fit** from **validated demand** in the app-fit framework (`minipay-app-fit.md`), and bump the skill to v2.7.0.

## Why

Today the scorecard sums 5 dimensions and returns **"Tier 1 — Build now"** at 8–10. But those dimensions prove *product-channel fit* — the idea works inside MiniPay's UX, tokens, and constraints — **not that anyone wants it**. A builder can score 10/10 and still fail because the market never existed.

This is a real, recurring failure mode:
- Local-stablecoin apps (e.g. a "Buy COP" mini app) that turn out not to fit MiniPay's priorities — MiniPay leads local-stablecoin "buy" flows through its Squid partnership (see Buy BTC / Buy ETH / Buy Gold in `minipay-live-apps.md`, all publisher **Squid**).
- "Buy X" / savings apps where **no real rail funds the wallet** in the target market, so the first dollar never arrives.

The framework should tell builders this *before* they build, while it's still cheap to change the idea.

## Changes (all in `minipay-app-fit.md`, one file)

1. **Two axes up front.** New intro note: **MiniPay Channel Fit** (does it work in the channel?) vs **Demand Evidence** (does anyone want it, and can the wallet be funded?). These are independent.
2. **Scorecard reframed** as the *Channel-Fit Scorecard* — states explicitly it measures channel fit only.
3. **Dimension E "Category gap" → "Catalog whitespace"**, with two explicit rules:
   - *"A live listing proves availability, not traction or problem resolution."*
   - *"Whitespace is not demand"* — zero competitors is ambiguous.
4. **New §3 — Demand Evidence & Source of Funds** (evaluated *separately*, never added to the score):
   - **Demand evidence** ladder: MiniPay-requested → Observed in MiniPay → Locally validated → External analogy only → Speculative.
   - **Source of funds**: who puts the first dollar in the wallet, and why — with a verify-the-rail check for manual on-ramps (cross-links `stablecoin-orchestration.md`; notes COP via Bre-B/PSE/ACH is still Beta).
5. **New §4 recommendation** replaces the single score→tier table, combining channel fit with demand: **build now / validate demand first / blocked by funding rail / wrong channel**.
6. Worked example and Category Opportunity Map updated to match.

`SKILL.md`: framework description refreshed, version → **2.7.0**.

## Scope / out of scope

Deliberately kept to one file and the two-axis reframe (points #1, #3, #5, #8 of a longer proposal). Left as **future evolution**, and intentionally not included here because they need an official source or a new maintenance system:
- A `minipay-opportunities.md` **wishlist** — only once MiniPay publishes an official source (the repo's rule is "never invent" reference data).
- **Rail verification status** taxonomy (production-verified / beta / unreliable) in `stablecoin-orchestration.md`.
- **Regional market context** with source/date/evidence-level on the per-country claims.
- A **pre-build concept brief** output.

## Note for reviewers

This edits `minipay-app-fit.md` (originally introduced in #9). Flagging for coordination with its maintainer — happy to adjust framing/labels. Opened as **draft** for discussion on the reframe before it's finalized.
