### PR TITLE
docs-watch: blocked — 2026-07-20

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-07-20 — BLOCKED (docs.celo.org, api.llama.fi,
+www.celopg.eco) — updated by every run, including blocked ones, per
+`SKILL.md` step 6. A `BLOCKED` value here means the most recent run
+couldn't reach one or more sources; check the linked PR for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Blocked run — 2026-07-20

This week's docs-watch run could not verify any of the 5 tracked sources — every fetch attempt was rejected before reaching the target host.

### Sources attempted

| # | Source | Host | Result |
|---|--------|------|--------|
| 1 | Docs sitemap (`docs.celo.org/llms.txt`) | `docs.celo.org` | ❌ Failed |
| 2 | Contract addresses (`docs.celo.org/tooling/contracts/*`) | `docs.celo.org` | ❌ Failed |
| 3 | Network info (`docs.celo.org/build-on-celo/network-overview`) | `docs.celo.org` | ❌ Failed |
| 4 | Ecosystem / TVL (`api.llama.fi/protocols`) | `api.llama.fi` | ❌ Failed |
| 5 | Grant programs (`www.celopg.eco/programs`) | `www.celopg.eco` | ❌ Failed |

**How it failed:** both `curl` and `WebFetch` attempts against `docs.celo.org/llms.txt` and `www.celopg.eco/programs` returned **HTTP 403 Forbidden**. The environment's outbound network proxy log (`__agentproxy/status`) confirms the root cause — the egress gateway rejected the CONNECT to `docs.celo.org:443` and `api.llama.fi:443` outright with `"gateway answered 403 to CONNECT (policy denial or upstream failure)"`, i.e. a network policy denial in this run's environment, not a site-side outage. `curl` to all three hosts returned connection-reset (exit code 56 / status `000`).

No source succeeded this run, so no reference files (`docs-map.md`, `contracts.md`, `network-info.md`, `ecosystem.md`, `grants-funding.md`) were touched and no version bump was made — nothing was actually re-verified.

### What this PR does

Only updates the `Last attempt` line in `.claude/skills/docs-watch/snapshot.md` to record the blocked attempt, per `SKILL.md`'s blocked-run procedure. This PR is informational — the real fix is unblocking egress to `docs.celo.org`, `api.llama.fi`, and `celopg.eco` for this environment (e.g. an allow-list update), not merging code. Merging just records the attempt; closing without merging is equally fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_019GQgomFbkjZHGSwv8MQED1)_