### PR TITLE
docs-watch: blocked — 2026-07-27

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-07-27 — BLOCKED (docs.celo.org, api.llama.fi,
+www.celopg.eco) — updated by every run, including blocked ones, per
+`SKILL.md` step 6. A `BLOCKED` value here means the most recent run
+couldn't reach one or more sources; check the linked PR for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Weekly docs-watch run — blocked

All 5 live sources this skill checks were unreachable this run. None of the reference-file diffs could be assessed, so no reference files were edited and no version bump was made — only the snapshot's `Last attempt` line was updated to record the attempt.

### Sources checked

| # | Source | Host | Result |
|---|---|---|---|
| 1 | Docs sitemap (`docs.celo.org/llms.txt`) | `docs.celo.org` | ❌ Blocked |
| 2 | Contract addresses (`docs.celo.org/tooling/contracts/*`) | `docs.celo.org` | ❌ Blocked |
| 3 | Network info (`docs.celo.org/build-on-celo/network-overview`) | `docs.celo.org` | ❌ Blocked |
| 4 | Ecosystem / TVL (`api.llama.fi/protocols`) | `api.llama.fi` | ❌ Blocked |
| 5 | Grant programs (`www.celopg.eco/programs`) | `www.celopg.eco` | ❌ Blocked |

**How they failed:** every attempt (via `curl` and via the `WebFetch` tool) got a `403 Forbidden`. The session's outbound network proxy confirmed this is an egress-policy denial, not a transient error — its diagnostic status endpoint recorded:

```
connect_rejected: gateway answered 403 to CONNECT (policy denial or upstream failure) — host: docs.celo.org:443
connect_rejected: gateway answered 403 to CONNECT (policy denial or upstream failure) — host: api.llama.fi:443
```

(`www.celopg.eco` failed the same way via `curl`.) No source succeeded this run.

### What changed

- `.claude/skills/docs-watch/snapshot.md`: updated the top-of-file `Last attempt` line to `2026-07-27 — BLOCKED (docs.celo.org, api.llama.fi, www.celopg.eco)`. Per-source facts are left untouched since nothing was actually re-verified.

### Not a content fix

This PR is informational — it records that the run happened and couldn't verify anything, so a blocked week is never silently indistinguishable from a clean one. The real fix is on the infrastructure side: this session's egress allow-list needs `docs.celo.org`, `api.llama.fi`, and `www.celopg.eco` added (or an equivalent networking change) before the next scheduled run can actually check for drift. Merging is optional — closing without merging is equally fine per the docs-watch skill.


---
_Generated by [Claude Code](https://claude.ai/code/session_016f2gzcoGwkDjvi1yhfwHx4)_