### PR TITLE
docs-watch: blocked — 2026-08-03

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-08-03 — BLOCKED (docs.celo.org, api.llama.fi,
+www.celopg.eco) — updated by every run, including blocked ones, per
+`SKILL.md` step 6. A `BLOCKED` value here means the most recent run
+couldn't reach one or more sources; check the linked PR for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
Weekly docs-watch run on 2026-08-03 could not verify any of the 5 live sources — this session's network egress policy blocked every host. No reference files were touched; only the snapshot's `Last attempt` line was updated, per `SKILL.md`'s blocked-run procedure.

## Sources attempted

| # | Source | Host | Result |
|---|---|---|---|
| 1 | Docs sitemap (`docs.celo.org/llms.txt`) | `docs.celo.org` | Failed — proxy returned `403` on CONNECT (`gateway answered 403 to CONNECT (policy denial or upstream failure)`, confirmed via the session's proxy status endpoint) |
| 2 | Contract addresses (`docs.celo.org/tooling/contracts/*`) | `docs.celo.org` | Failed — same `403` policy denial (WebFetch on all 4 pages: core-contracts, token-contracts, l1-contracts, uniswap-contracts) |
| 3 | Network info (`docs.celo.org/build-on-celo/network-overview`) | `docs.celo.org` | Failed — same `403` policy denial |
| 4 | Ecosystem / TVL (`api.llama.fi/protocols`) | `api.llama.fi` | Failed — proxy returned `403` on CONNECT, same policy-denial class |
| 5 | Grant programs (`www.celopg.eco/programs`) | `www.celopg.eco` | Failed — `403 Forbidden` via WebFetch |

**0 of 5 sources reachable.** No deltas could be assessed this run.

Per the proxy README, `403`/`407` from the gateway means the destination host isn't on this session's egress allow-list, and shouldn't be retried — the real fix is on the environment/network-policy side (e.g. adding `docs.celo.org`, `api.llama.fi`, and `www.celopg.eco` to the allow-list for this environment), not something this PR can resolve.

## What changed

- `.claude/skills/docs-watch/snapshot.md`: updated the top-of-file `Last attempt` line to `2026-08-03 — BLOCKED (docs.celo.org, api.llama.fi, www.celopg.eco)`. All per-source facts are left untouched since nothing was actually re-verified.

This PR is informational — merging just records the attempt; closing without merging is equally fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_014RqaNjipvagS6Bn7uRDQkv)_