### PR TITLE
feat(usat): add USA₮ to fee abstraction table in builder-guide

### DIFF
--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -55,9 +55,8 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 | USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
 | USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
 | USA₮ | 6 | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (adapter) |
-| USAT | 6 | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (adapter) |
 
-> **USA₮ / USAT** (Tether America USD) — US-regulated dollar issued by Anchorage Digital Bank, N.A. (first federally chartered digital asset bank in the US). GENIUS Act compliant. Launched on Celo Mainnet March 31, 2026. **Not the same as USDT** — different issuer, different trust profile, designed for institutional and compliance-sensitive use cases. Caveat: some Valora-derived wallets may show `priceUsd: NaN` until oracles index the Celo contract address; transactions work correctly.
+> **USA₮** (Tether America USD) — US-regulated dollar issued by Anchorage Digital Bank, N.A. (first federally chartered digital asset bank in the US). GENIUS Act compliant. Launched on Celo Mainnet March 31, 2026. **Not the same as USD₮ (USDT)** — different issuer, different trust profile, designed for institutional and compliance-sensitive use cases.
 
 The table above is the common subset. The **full allowlist is larger** — it also includes many Mento local-currency stablecoins (KESm, COPm, GHSm, NGNm, ZARm, GBPm, and more) plus a few other assets. Rather than hardcode the whole list, **fetch it live** with `getCurrencies()` (see below) — that's the canonical, always-current source. For MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold, so default to those.
 

--- a/skills/celopedia-skill/references/builder-guide.md
+++ b/skills/celopedia-skill/references/builder-guide.md
@@ -54,6 +54,10 @@ Users can pay gas fees with ERC-20 tokens instead of native CELO. This is Celo's
 | BRLm (cREAL) | 18 | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` (same) |
 | USDC | 6 | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (adapter) |
 | USDT | 6 | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` (adapter) |
+| USA₮ | 6 | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (adapter) |
+| USAT | 6 | `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` | `0x0357EE22278c922e1D36cFe6b899269b161880C4` (adapter) |
+
+> **USA₮ / USAT** (Tether America USD) — US-regulated dollar issued by Anchorage Digital Bank, N.A. (first federally chartered digital asset bank in the US). GENIUS Act compliant. Launched on Celo Mainnet March 31, 2026. **Not the same as USDT** — different issuer, different trust profile, designed for institutional and compliance-sensitive use cases. Caveat: some Valora-derived wallets may show `priceUsd: NaN` until oracles index the Celo contract address; transactions work correctly.
 
 The table above is the common subset. The **full allowlist is larger** — it also includes many Mento local-currency stablecoins (KESm, COPm, GHSm, NGNm, ZARm, GBPm, and more) plus a few other assets. Rather than hardcode the whole list, **fetch it live** with `getCurrencies()` (see below) — that's the canonical, always-current source. For MiniPay Mini Apps and consumer payments, **USDm, USDC, and USDT** are the fee currencies users actually hold, so default to those.
 


### PR DESCRIPTION
## Summary

Adds **USA₮ (Tether America USD)** to the fee abstraction reference table in `builder-guide.md`.

## Changes

**`skills/celopedia-skill/references/builder-guide.md`**
- New row in the whitelisted fee currencies table: USA₮ token address + adapter address
- Inline note clarifying: issuer (Anchorage Digital Bank, N.A.), GENIUS Act compliance, USA₮ ≠ USDT distinction, `priceUsd: NaN` display caveat for Valora-derived wallets

## Context

USA₮ launched on Celo Mainnet on March 31, 2026, as a whitelisted fee currency from day one. The contract address and note were already added to `contracts.md` in a prior upstream commit. This PR adds the adapter address and builder context to the fee abstraction table in `builder-guide.md` — the place builders look when implementing `feeCurrency`.

Key facts:
- Token: `0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771` (6 decimals)
- feeCurrency adapter: `0x0357EE22278c922e1D36cFe6b899269b161880C4` (use this, not the token address)
- Issuer: Anchorage Digital Bank, N.A. (first federally chartered digital asset bank in the US)
- GENIUS Act compliant — different trust profile from USDT