### PR TITLE
docs-watch: blocked - 2026-08-10

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-08-10 — BLOCKED (celopg.eco) — updated by every run,
+including blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means
+the most recent run couldn't reach one or more sources; check the linked PR
+for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Blocked run — not a content update

This week's docs-watch run could not verify all 5 live sources, so per the skill's spec this run is classified **blocked**. Only `snapshot.md`'s "Last attempt" line was updated — no reference files were touched and no version bump was made, since nothing was fully verified this run.

### Failed source

- **`www.celopg.eco` / `celopg.eco`** (Grant programs, source #5 in `SKILL.md`)
  - `curl -sI https://www.celopg.eco/programs` → `301` redirect to `https://celopg.eco/programs`
  - Following that redirect fails: `curl -sL` → exit 56 (connection reset), no response
  - `WebFetch` on the same URL → `EGRESS_BLOCKED`: "Access to celopg.eco is blocked by the network egress proxy"
  - Confirmed via two independent methods (direct curl and WebFetch), so this isn't a transient blip on one tool.

### Sources that succeeded this run

- `docs.celo.org/llms.txt` (sitemap) — reachable, `200`
- `docs.celo.org/tooling/contracts/*` and `docs.celo.org/build-on-celo/network-overview` — reachable
- `api.llama.fi/protocols` (DefiLlama) — reachable, `200`

Real drift was observed on these reachable sources (a docs.celo.org navigation reorg — Token Contracts split into Stablecoin Contracts + Fee Currencies pages, Fee Abstraction moved under `build-on-celo/`, old hardfork notices moved under `/archive/`; plus a few DeFi protocols on Celo not yet in `ecosystem.md`, notably Tether Gold at ~$3.1B TVL). Per the skill's rule that any unreachable source makes the whole run "blocked," none of those mechanical fixes were applied here — they'll need to be re-detected and applied on a future clean/drift run once `celopg.eco` is reachable again.

### Fix needed

The real fix is on the infrastructure side — `celopg.eco` needs to be reachable from this environment's network egress (allow-list, or the egress proxy blocking it needs to be adjusted). This PR is informational; merging it just records the attempt, and closing without merging is equally fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_016rVsB3Kgkk86SoSvXtfMz4)_