### PR TITLE
docs-watch: blocked — 2026-08-17

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,13 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-08-17 — BLOCKED (celopg.eco: 403 Forbidden, blocked by
+network egress policy). Sources 1-4 (docs.celo.org sitemap, contracts pages,
+network-overview, DefiLlama) were reachable this run, but per SKILL.md a
+blocked source makes the whole run Blocked — no reference files were
+touched. Updated by every run, including blocked ones, per `SKILL.md`
+step 6. A `BLOCKED` value here means the most recent run couldn't reach one
+or more sources; check the linked PR for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Blocked run

This week's docs-watch run could not fully verify all live sources, so per `.claude/skills/docs-watch/SKILL.md` this is a **blocked** run: no reference files were touched, no version bump — only `snapshot.md`'s "Last attempt" line was updated to record the attempt.

### Failed

| Source | Result |
|---|---|
| Grant programs — `www.celopg.eco/programs` (→ `grants-funding.md`) | **403 Forbidden** — blocked by this environment's network egress proxy (confirmed via both `WebFetch` and direct `curl`, both `www.celopg.eco` and `celopg.eco`) |

### Reachable this run (not applied — see note below)

| # | Source | Result |
|---|---|---|
| 1 | Docs sitemap — `docs.celo.org/llms.txt` | 200 OK |
| 2 | Contract addresses — `docs.celo.org/tooling/contracts/*` | 200 OK (core, token, l1, uniswap) |
| 3 | Network info — `docs.celo.org/build-on-celo/network-overview` | 200 OK |
| 4 | Ecosystem / TVL — `api.llama.fi/protocols` | 200 OK |

Sources 1-4 fetched cleanly and some deltas were visible in the fetched data (e.g. a new docs page `build-on-celo/build-with-ai/mpp.md` not yet in `docs-map.md`; DefiLlama's Celo-chain listing for Uniswap V4 looked worth a second look against `contracts.md`'s Uniswap V4 addresses). Per SKILL.md, a run where any source is unreachable is classified as **Blocked** as a whole, so none of that was applied or recorded here — it'll be picked up fresh on the next successful run.

### Next step

The real fix is on the network egress allow-list for this environment (`celopg.eco` needs to be reachable). This PR is informational — merging just records the attempt; closing without merging is equally fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W1njrJUCnzfsQ2bjyfzCPG)_