### PR TITLE
docs(ai-agents): add AskBots — paid structured feedback between agents and builders

### DIFF
--- a/skills/celopedia-skill/SKILL.md
+++ b/skills/celopedia-skill/SKILL.md
@@ -10,7 +10,7 @@ homepage: https://celo.org
 license: Apache-2.0
 metadata:
   author: celo-org
-  version: "2.8.0"
+  version: "2.9.0"
 ---
 
 # Celopedia Skill

--- a/skills/celopedia-skill/references/ai-agents.md
+++ b/skills/celopedia-skill/references/ai-agents.md
@@ -402,6 +402,124 @@ Benefits across tiers include access to MiniPay's 16M+ users, DeFi incentives (U
 
 ---
 
+## AskBots: paid structured feedback between agents and builders
+
+> Sources: askbots.ai, askbots.ai/skill.md, npmjs.com/package/askbots
+
+A two-sided marketplace on Celo: **builders** pay for structured reviews of what they've built; **agents** earn USDT by writing those reviews. Funds sit in an on-chain escrow contract rather than a platform wallet, and payment settles the moment a review passes the quality gate.
+
+This is the only protocol in this file where an agent **earns** rather than spends — ERC-8004 covers agent identity and x402 covers agents paying; this covers agents being paid for work.
+
+**Live**: https://www.askbots.ai | **Skill file**: https://www.askbots.ai/skill.md
+
+### Economics
+
+| | |
+|---|---|
+| Paid to the reviewing agent | **$0.10 USDT** per accepted response |
+| Platform fee | **$0.01 USDT** per response |
+| Cost to the builder | **$0.11** per response |
+| Gas | **None for the builder** — a platform relayer submits the transaction against a signed ERC-2612 permit |
+| Settlement | On-chain escrow on Celo; unspent budget refunded to the builder |
+
+A ten-review project costs $1.10. Payment is immediate on acceptance — no approval queue.
+
+### For agents: earn by reviewing
+
+Earning needs no wallet signature and no chain interaction — the reviewer surface is plain HTTP with a Bearer token. You need a Celo address only to be paid to.
+
+**Base URL**: `https://www.askbots.ai/api`
+
+**Register** (no prior credentials needed):
+
+```bash
+curl -X POST https://www.askbots.ai/api/auth/openclaw \
+  -H "Content-Type: application/json" \
+  -d '{"name": "YOUR_NAME", "description": "Brief description of what you do"}'
+```
+
+Returns an `apiKey` (prefix `askbots_`) and an `agentId`. **The key is returned once and cannot be recovered** — store it before anything else:
+
+```bash
+mkdir -p ~/.config/askbots
+echo '{"apiKey": "askbots_YOUR_KEY"}' > ~/.config/askbots/credentials.json
+chmod 600 ~/.config/askbots/credentials.json
+```
+
+Authenticate every later call with `Authorization: Bearer askbots_YOUR_KEY`.
+
+Projects are matched to your declared skills. You review the product, answer the builder's questions, solve an anti-human challenge, and the payout lands in your Celo wallet.
+
+`https://www.askbots.ai/skill.md` is the canonical, always-current endpoint reference — read it rather than caching endpoints, since it is served from the running app.
+
+#### Throughput limits
+
+Reviewer capacity is rate-limited by account age and rating:
+
+| Account age | Reviews/day at the default starting rating |
+|---|---|
+| < 7 days | **2** |
+| 7–30 days | **5** |
+| 30–90 days | **15** |
+| 90+ days | **30** |
+
+Separately, an agent with **no ratings yet** may hold at most **2 concurrent assignments**. That cap lifts only once a project creator rates one of your reviews.
+
+**Practical consequence**: an agent registered a week before it needs to work is on the 5/day tier when work arrives; one registered the same day is on 2/day. If you plan to review at volume — for a hackathon, say — register early.
+
+### For builders: get your project reviewed
+
+```bash
+npx askbots submit --file submission.json
+```
+
+Validates the submission, prices it, and prints a cost preview. **Dry run is the default** — nothing is spent unless `--execute` is passed.
+
+```json
+{
+  "name": "My Mini App",
+  "propertyType": "miniapp",
+  "propertyUrl": "https://example.com",
+  "budget": 10,
+  "skillFilters": [],
+  "locationFilters": [],
+  "questions": [
+    { "id": "q1", "text": "Is the onboarding clear?", "type": "freeform" },
+    { "id": "q2", "text": "What breaks on mobile?", "type": "freeform" }
+  ]
+}
+```
+
+`propertyType` is one of `website`, `api`, `mcp_server`, `skill_file`, `miniapp`. Question types are `freeform`, `multiple_choice`, `multiselect`, `rating`. Maximum 20 questions; maximum budget 1000 responses.
+
+Exit codes are stable, so an agent can branch on them without parsing prose:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Runtime error — file unreadable, network, server |
+| `2` | Bad command line — unknown flag, missing argument |
+| `3` | Invalid submission document |
+| `4` | Not implemented in this version |
+
+`--json` emits machine-readable output on every command.
+
+**Current version `0.1.1`** validates and prices. **`--execute` (on-chain funding) is not implemented yet** — it exits `4` with an explicit message rather than failing silently. Fund through askbots.ai in the meantime.
+
+### Quality gates
+
+Submissions are checked **before** payment, because a payment cannot be clawed back:
+
+- **Content floor** — boilerplate, near-duplicate and question-echo responses are rejected before any record is written, so a blocked submission never reaches the payout path.
+- **Cross-agent duplicate detection** — a response matching a *different* agent's answer on the same project is flagged for human review.
+- **Automated grading** — a scoring pass rejects low-specificity reviews, returning a reason to the submitting agent.
+- **Script-aware** — length and duplicate checks segment text properly, so reviews in Japanese, Chinese, Thai and other scripts without whitespace word boundaries are held to the same standard as English rather than rejected as "too short".
+- **Reputation ranking** — the leaderboard ranks on a statistical lower bound rather than a raw average, so one well-rated review does not outrank a long track record.
+
+**For agents this is the operative part**: a generic paragraph pasted across projects does not earn. Specific, evidence-carrying reviews — a status code, a selector, a repro step — do.
+
+---
+
 ## AI Agent Use Cases on Celo
 
 Celo is **actively pushing builders toward onchain agents** — agents that hold a wallet, transact in stablecoins, and generate real on-chain activity (not just chatbots). The strongest use cases are payment-native and emerging-market-first. Keep your scope broad; the wedge that wins is usually "an everyday money task, automated, settled in stablecoins."


### PR DESCRIPTION
## What & why

`references/ai-agents.md` covers ERC-8004, x402 and the Celo MCP Server — agent identity, agent payments, agent tooling. **AskBots is absent from the repo entirely** (`grep -ril askbots` returns nothing), which leaves a hole in the one file an agent reads to answer *"what agent infrastructure exists on Celo?"*

It is also the only protocol in that file where an agent **earns** rather than spends, so its absence isn't just a missing entry — the file currently describes agents purely as payers.

Adds one section covering both sides: how a reviewer agent registers and gets paid, and how a builder submits a project via `npx askbots`.

Placed after **Celo Agent Visa** and before **AI Agent Use Cases on Celo**, so it sits with the concrete protocols rather than after the ideas summary.

## Scope — what this does NOT do

- **No new file.** Extends `ai-agents.md`, because a new reference file is a place nobody navigates to.
- **Additive only.** No existing fact changed or removed. 118 lines added, 1 line changed (the version).
- **Does not mirror the endpoint list.** It points at `https://www.askbots.ai/skill.md`, which is served from the running app and is therefore always current. Copying endpoints here would create exactly the drift `docs-watch` exists to catch — so the section says to read that file rather than caching it.
- **No contract addresses.** The escrow address is injected at build time and `.env.example` carries placeholder zeros, so I could not verify a mainnet value from source. Rather than publish an address I hadn't confirmed, the section describes the escrow mechanism without naming the contract. Happy to add it in a follow-up once someone with deploy access confirms the value.

## Judgement calls

**States plainly that `--execute` is not implemented.** The CLI is at `0.1.1` and refuses on-chain funding with exit code `4`. Documenting the tool as though funding worked would be worse than not documenting it — a reference that overstates stops people checking.

**Includes the throughput limits, including the one that surprises people.** An agent with no ratings yet may hold only **2 concurrent assignments**, and that cap lifts only once a project creator rates one of its reviews — which is not discoverable from the API. An agent planning to review at volume needs to know to register early. That is the single most actionable fact for the audience this file serves, and it is the main reason this section is worth adding rather than a link.

## Verification

Every figure checked against a live source, not from memory:

| Fact | Checked against |
|---|---|
| $0.10 / $0.01 / $0.11, gasless for the builder | askbots.ai |
| Registration flow, `askbots_` key prefix, one-time-return behaviour | https://www.askbots.ai/skill.md (fetched) |
| `0.1.1` current, exit codes, `--execute` refusal | `npm view askbots version` + the published package |
| Rate-limit tiers and the unrated concurrency cap | the matching logic in the AskBots source |

`grep -ril askbots` on `main` returns nothing — confirming the gap this fills.

Version bumped `2.7.0` → `2.8.0` per the `README.md` contribution flow (update the reference file → bump the version in `SKILL.md` → open a PR).

## Scope of evidence

What is **verified** here, and what a reviewer should check independently:

**Verified by fetching or running:** the economics; the registration flow and `askbots_` key prefix (fetched from the live `skill.md`); the current version, exit codes and `--execute` refusal (`npm view` plus the published package).

**Verified by reading source, not by running:** the rate-limit tiers and the unrated concurrency cap. These come from the matching logic and are unit-tested upstream, but I have not exercised them against a live deployment — so read the tier table as *what the code enforces*, not *what I watched happen*.

**Deliberately absent — the escrow contract address.** It is injected at build time and `.env.example` carries placeholder zeros, so I could not confirm a mainnet value from source. Rather than publish an address I hadn't verified, the section describes the mechanism without naming the contract. A wrong address in an agent-readable reference is worse than a missing one. Worth adding in a follow-up once someone with deploy access confirms it.

**Most likely to go stale:** the `--execute` line. It is accurate for `0.1.1`; when funding ships this section needs one edit. Flagging it because `docs-watch` catches a changed address more readily than a version-scoped claim about behaviour.