### PR TITLE
Add Chainstack to the Celo RPC provider list

### DIFF
--- a/skills/celopedia-skill/references/network-info.md
+++ b/skills/celopedia-skill/references/network-info.md
@@ -63,9 +63,19 @@ The `FeeCurrencyDirectory` contract at `0x15F344b9E6c3Cb6F0376A36A64928b13F62C62
 | QuickNode | Global edge network, Streams |
 | Infura (Consensys) | Standard Ethereum-style RPC |
 | Ankr | All-in-one Web3 hub |
+| Chainstack | Geo-load-balanced global nodes. Archive data and debug/trace APIs on paid plans. **Celo mainnet only** — its docs list network ID 42220 and no testnet |
 | Lava | Decentralized RPC network |
 | OnFinality | Multi-chain RPC |
 | Dwellir | Nordic-hosted nodes |
+
+Provider endpoints are per-account and issued from each dashboard, so there is no
+shared URL to publish for them. Chainstack endpoints are key- or password-protected
+(`https://USERNAME:PASSWORD@HOSTNAME` for the latter).
+
+**Reach for a provider when Forno's rate limit starts shaping your app.** Forno is free
+and fine for development and for most reads. The usual trigger for moving is an agent or
+backend making sustained calls, or needing archive state and `debug_*` / `trace_*`, which
+Forno does not serve.
 
 ## Block Explorers
 


### PR DESCRIPTION
## Why

`network-info.md`'s **RPC Providers** table lists eight providers and not Chainstack, which serves Celo mainnet. An agent asked "what are my RPC options on Celo" gets an incomplete answer today.

## What changed

One row added to the table, plus two clarifications the table implied but never stated.

**The scope note is the part worth reviewing.** The row says **Celo mainnet only**, because that is what Chainstack documents:

- [chainstack.com/build-better-with-celo](https://chainstack.com/build-better-with-celo/) — "Run high-performing Celo nodes", references Celo Mainnet
- [docs.chainstack.com](https://docs.chainstack.com/docs/celo-tooling) — network ID **42220**, no Alfajores, no Sepolia

Neither page mentions a testnet. Recording that explicitly matters because "use a dedicated provider" is bad advice for someone building on Celo Sepolia, which is where most builders start and where the faucets point.

If Chainstack adds testnet coverage, the row should be updated rather than the caveat quietly dropped.

## The two clarifications

- **Endpoints are per-account**, issued from each dashboard, so there is no shared URL to publish for any of these providers. The table previously listed names with no indication of how you get a URL. Chainstack's are key- or password-protected (`https://USERNAME:PASSWORD@HOSTNAME` for the latter).
- **When to leave Forno.** Forno is free and fine for development and most reads. The real triggers are sustained call volume, or needing archive state and `debug_*` / `trace_*`, which Forno does not serve. Without that, "for production, use a dedicated RPC provider" reads as "pay someone immediately".

## Deliberately not included

No coupon code or hackathon promotion. Chainstack sponsoring the Agents at Work hackathon is time-bound and belongs on the hackathon's own surfaces; this file is evergreen reference material and a code in it is stale the day the event ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)