### PR TITLE
docs-watch: blocked - 2026-08-31

### DIFF
--- a/.claude/skills/docs-watch/snapshot.md
+++ b/.claude/skills/docs-watch/snapshot.md
@@ -4,10 +4,10 @@ Baseline seeded: 2026-07-07 (from the repo's own reference files, not a fresh
 live fetch — their own "Last updated" stamp is 2026-04-15, so treat this
 snapshot as unverified against live sources until the first real run).
 
-Last attempt: none yet (baseline only) — updated by every run, including
-blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means the most
-recent run couldn't reach one or more sources; check the linked PR for
-which ones.
+Last attempt: 2026-08-31 — BLOCKED (celopg.eco) — updated by every run,
+including blocked ones, per `SKILL.md` step 6. A `BLOCKED` value here means
+the most recent run couldn't reach one or more sources; check the linked PR
+for which ones.
 
 ## 1. Docs sitemap (`docs-map.md`)
 


### PR DESCRIPTION
## Blocked run — 2026-08-31

This week's `docs-watch` run could not reach one of its 5 sources, so per `SKILL.md`'s "Blocked" outcome this PR only records the attempt (updates `snapshot.md`'s `Last attempt` line) — no reference files were edited and no version bump was made, since nothing was fully verified this run.

### Failed

| # | Source | Host | Error |
|---|---|---|---|
| 5 | Grant programs | `www.celopg.eco` (redirects to `celopg.eco`) | Blocked by the network egress proxy — `connect_rejected (organization policy)`. Confirmed with both the `WebFetch` tool (`EGRESS_BLOCKED`) and a direct `curl` (proxy `CONNECT` to `celopg.eco:443` rejected). |

### Succeeded

| # | Source | Fetched via |
|---|---|---|
| 1 | Docs sitemap (`docs.celo.org/llms.txt`) | `curl` |
| 2 | Contract addresses (`docs.celo.org/tooling/contracts/*`) | `curl` (raw `.md`) + WebFetch |
| 3 | Network info (`docs.celo.org/build-on-celo/network-overview`) | `curl` (raw `.md`) |
| 4 | Ecosystem / TVL (`api.llama.fi/protocols`) | `curl` |

### Informational — findings from the 4 reachable sources (not applied)

Since these can't be folded into a "verified" run while source 5 is down, nothing below was written to the reference files. Flagging for whoever unblocks `celopg.eco` access, so the next clean run has a head start:

- **`docs-map.md` vs live sitemap**: substantial drift. `docs.celo.org` has reorganized `infra-partners/notices/*`, `infra-partners/operators/*` and `infra-partners/specs` into a new top-level `operate/*` section, and dropped `infra-partners/integration/*` entirely (no replacement found). `tooling/contracts/token-contracts` now redirects (308) to `tooling/contracts/fee-currencies`, with a new sibling page `tooling/contracts/stablecoin-contracts` — the old page's content split in two. Most of `build-on-minipay`'s tracked pages (`quickstart`, `code-library`, `deeplinks`, `ngrok-setup`) are gone from the sitemap. This needs a human pass, not a mechanical rename — a future run should treat it as `needs review`.
- **`contracts.md`**: verified clean. Every address in Core Protocol Contracts, L1 Contracts, Uniswap V3/V4, and the Mento + external stablecoin tables matches docs.celo.org exactly, including `CeloUnreleasedTreasury` and `EpochManagerEnabler`, which are already correctly tracked.
- **`network-info.md`**: chain IDs, RPC, and block explorer URLs all match live. The Fee-Accepted Tokens table is stale though — the live `fee-currencies` page (autogenerated from the `FeeCurrencyDirectory` contract) now allowlists ~20 tokens (all 15 Mento stablecoins, plus USDC/USD₮/USA₮ via adapters, plus WETH and a new `XAUt0` gold token) vs. the 4 currently documented. Likely a straightforward `reference update` next time.
- **`ecosystem.md`**: Uniswap V4 doesn't appear in DefiLlama's Celo chain list for that protocol, but its contract addresses are confirmed live on docs.celo.org — likely just DefiLlama not indexing TVL yet, not an actual removal. A few sizeable protocols with real TVL aren't tracked (SushiSwap ~$39M, Velodrome V2 ~$15M, Moola Market ~$994K — has 2021 hack history). Worth a curation pass, not urgent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZp5BDnvUd62ysii6w4eBq)_