### PR TITLE
chore: install the issue Priority/Size labeler and add a truthful CLAUDE.md

### DIFF
--- a/.github/workflows/issue-priority-label.yml
+++ b/.github/workflows/issue-priority-label.yml
@@ -30,6 +30,16 @@ jobs:
           # Each dropdown renders as "### <Label>" followed by the selected option.
           # Options carry a description ("critical — money correctness …", "S — hours"),
           # so only the first word is the value.
+          #
+          # Matching is on the RENDERED heading, not the form's field id. That matters:
+          # bug_report.yml's Priority dropdown has id `severity` but renders as
+          # "### Priority (one per issue — …)", so it is read correctly. Grepping the
+          # form for `id: priority` will tell you otherwise; the id is not what ships.
+          #
+          # The match is a prefix, which is what makes the long bug_report label work.
+          # Cost: a future heading like "### Priority rationale" would also match and
+          # its first word would be taken as the value. No such heading exists in any
+          # form today; if one is added, tighten this.
           field() {
             printf '%s\n' "$BODY" \
               | awk -v h="^### $1" '$0 ~ h {found=1; next} found && NF {print $1; exit}' \
@@ -37,8 +47,8 @@ jobs:
           }
 
           # --- Priority ---
-          # bug_report.yml has no Priority dropdown, so an empty result here is
-          # expected, not an error. Same for an issue filed without the form.
+          # All three forms carry a Priority dropdown. An empty result here means the
+          # issue was filed outside the forms, which is expected, not an error.
           p=$(field Priority | tr '[:upper:]' '[:lower:]')
           case "$p" in
             critical|high|medium|low)

--- a/.github/workflows/issue-priority-label.yml
+++ b/.github/workflows/issue-priority-label.yml
@@ -1,0 +1,65 @@
+# Turns the issue forms' required "Priority" and "Size" dropdowns into the matching
+# priority:* / size:* labels, so every ticket carries both from the moment it's filed.
+# Uses only the repo-scoped GITHUB_TOKEN — no secrets to configure.
+#
+# The name is load-bearing: .claude/shared/engineering-rules.md (synced from pm-kit,
+# so it cannot be corrected locally) refers to "the issue-priority-label workflow".
+# Renaming this file makes that reference dangle again.
+name: Label issue priority
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply priority and size labels from the form dropdowns
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY: ${{ github.event.issue.body }}
+          NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Each dropdown renders as "### <Label>" followed by the selected option.
+          # Options carry a description ("critical — money correctness …", "S — hours"),
+          # so only the first word is the value.
+          field() {
+            printf '%s\n' "$BODY" \
+              | awk -v h="^### $1" '$0 ~ h {found=1; next} found && NF {print $1; exit}' \
+              | tr -d '\r'
+          }
+
+          # --- Priority ---
+          # bug_report.yml has no Priority dropdown, so an empty result here is
+          # expected, not an error. Same for an issue filed without the form.
+          p=$(field Priority | tr '[:upper:]' '[:lower:]')
+          case "$p" in
+            critical|high|medium|low)
+              for other in critical high medium low; do
+                [ "$other" != "$p" ] && gh issue edit "$NUM" -R "$REPO" --remove-label "priority:$other" 2>/dev/null || true
+              done
+              gh issue edit "$NUM" -R "$REPO" --add-label "priority:$p"
+              echo "labeled #$NUM priority:$p"
+              ;;
+            *) echo "no priority selection found (got: '$p') — skipping priority" ;;
+          esac
+
+          # --- Size ---
+          s=$(field Size | tr '[:lower:]' '[:upper:]')
+          case "$s" in
+            S|M|L)
+              for other in S M L; do
+                [ "$other" != "$s" ] && gh issue edit "$NUM" -R "$REPO" --remove-label "size:$other" 2>/dev/null || true
+              done
+              gh issue edit "$NUM" -R "$REPO" --add-label "size:$s"
+              echo "labeled #$NUM size:$s"
+              ;;
+            *) echo "no size selection found (got: '$s') — skipping size" ;;
+          esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md — celopedia-skills
+
+> Repo-owned. Keep it LEAN: a router. Shared rules are imported below and synced from pm-kit — don't restate them here. Every Claude session (local, Cowork, CI action) reads this.
+
+## What this project is
+
+The Celopedia skill: a comprehensive, installable agent skill for building on Celo — ecosystem intelligence, developer tools, DeFi protocols, MiniPay integration, AI agent infrastructure, governance, grants, and verified contract addresses. Consumed by developers and AI agents via `npx skills add celo-org/celopedia-skills` (Codex/OpenClaw) or copied under `.claude/skills/` for Claude Code. The published skill content IS the product — there is no app or server.
+
+## Commands
+
+**There is no build, no test suite, and no package manager here** — no `package.json`,
+no `Makefile`. The published markdown IS the artifact, so "does it build" is not a
+question this repo can answer. Verify content by reading it and by checking claims at
+their source (see Gotchas).
+
+The only executable things in the repo:
+
+- `scripts/generate_minipay_live_apps.py` — rebuilds the MiniPay live-apps list; edit
+  the generator, never its output
+- `scripts/collect_traffic_stats.sh` — weekly usage snapshot; run by
+  `.github/workflows/usage-stats.yml`, writes to the `stats` branch
+
+If you add a runner, update this section and `.github/workflows/` in the same PR.
+
+## Architecture pointers
+
+- `skills/celopedia-skill/` — the skill itself: SKILL.md plus reference files; this is what installs into agents
+- `scripts/` — content generators (e.g. `generate_minipay_live_apps.py` builds the live-apps list)
+- `.github/workflows/celopedia-skill-tag.yml` — tags skill releases from the `version:` in `SKILL.md`
+- `.github/workflows/issue-priority-label.yml` — turns the issue forms' Priority/Size dropdowns into labels
+- `.claude/skills/` — local mirror so sessions in this repo load the skill
+
+## Team rules (shared, synced — read them)
+
+@.claude/shared/engineering-rules.md
+
+Money/security diffs additionally run: @.claude/shared/money-path-checklist.md
+Before a real-money / real-send path goes public, it runs in production behind tester mode: @.claude/shared/tester-mode-pattern.md
+
+The ten you must never violate, even without reading the above:
+1. Never push to `main`. Branch `<handle>/<issue>-<slug>` → PR → squash. Title = the commit on `main` (Conventional Commits, scoped, outcome).
+2. One concern per PR, one fix-unit per issue, one priority per issue.
+3. Every change ships the test that fails on pre-fix code, through the seam it touches (route/CLI/component), and any prose guarantee is tested on its failure path. State the mutation count in the PR.
+4. `Closes #N` only if every acceptance box is met; otherwise `Refs #N`. After merge, check what actually closed.
+5. Every claim in an issue/PR/review is evidence-backed: commands + output, `file:line`. "Confirmed" means you ran it. Measured over reasoned — thresholds and constants pinned in a test, not a comment.
+6. Say what the PR does NOT do (with numbers). Say what it actually does, even beyond the ticket. Flag judgement calls and bundled product changes for the maintainer.
+7. On review feedback: reproduce first, fix, audit your own fix, report what it taught. Answer every point FIXED / NOT-FIXED / DISAGREE-with-measurement; never a silent push; never delete a wrong claim — strike it through.
+8. Use only existing labels: `bug` `enhancement` `chore` `priority:critical|high|medium|low` `size:S|M|L` `status: triage`. Never invent labels. Priority and Size are set by the issue form's dropdowns and applied automatically by `.github/workflows/issue-priority-label.yml`; add them by hand only when filing outside the form.
+9. Ask before anything outward-facing or irreversible (external repos, posting, deleting, force-pushing shared branches). Propose, never execute.
+10. No secrets in diffs. New env vars → `.env.example` + runbook, in the same PR.
+
+Use the plugin commands: `/file-issue`, `/write-pr`, `/review-pr`, `/post-merge`, `/close-pr`.
+
+## Product context
+
+- Team board: https://github.com/orgs/celo-org/projects/209
+
+## Gotchas
+
+- Facts in skill content must be verified at the source (contract addresses via explorer/`eth_call`, not memory) — wrong addresses in an installed skill propagate to every consumer agent
+- Claude Code only discovers skills under `.claude/skills/` — `npx skills add` alone is not enough (see README install options)
+- Generated sections (e.g. MiniPay live apps) are rebuilt by `scripts/` — edit the generator, not the output


### PR DESCRIPTION
## The hole, and the fix

`.claude/shared/engineering-rules.md` is **synced from pm-kit** (that is what #51, #52 and #63 were), so its claims cannot be corrected in this repo — the next sync overwrites any local edit. It currently tells every contributor and agent:

> *"the `issue-priority-label` workflow converts the selection into the label automatically… **Size the work at filing** — `size:S/M/L` via the form's Size dropdown, **auto-labeled the same way**"*

Neither was true here:

```
$ git ls-tree origin/main --name-only .github/workflows/
.github/workflows/celopedia-skill-tag.yml
.github/workflows/usage-stats.yml          # no issue-priority-label

$ gh label list | grep size:
(nothing)
```

The forms *do* carry the required Priority and Size dropdowns, so the input existed with nothing consuming it. Since the doc can't be fixed locally, the only durable fix is to make reality match it. That is what this does.

This also salvages #50, which is `DIRTY/CONFLICTING`: 8 of its 11 files already landed via the pm-kit syncs, and on 4 of those `main` is now **newer**, so merging #50 would regress them. Only two things in it were worth keeping.

**What's here:**
- `.github/workflows/issue-priority-label.yml` — #50's workflow, extended to handle **Size** as well as Priority. Filename kept deliberately: the synced doc names it, so renaming makes the reference dangle again.
- `size:S` / `size:M` / `size:L` labels created on the repo — `gh issue edit --add-label` fails without them.
- `CLAUDE.md` — #50's version with the **Commands section rewritten**. It listed `npm install` and `npm run dev/test/lint/typecheck/build` against a repo with **no `package.json` and no test suite**, so merging #50 as-is would have sent every Claude session after six commands that do not exist.

## What this does NOT do / residual risk

- ~~**Bug reports still get no priority label.**~~ **Wrong — corrected in `d8a5530`.** `bug_report.yml` *does* have a Priority dropdown; its `id` is `severity` but it renders as `### Priority (one per issue — …)`, and the parser matches the rendered heading, not the id. I had grepped the form for `id: priority`. All three forms label correctly. No pm-kit change is needed.
- **The board auto-add claim is still unverified.** The same doc says every issue lands on the project board automatically. I added #62 by hand, so I cannot say whether auto-add fires. Untested either way.
- **The workflow has never run.** It is `on: issues`, so nothing in CI exercises it and there is no green run to link until the next issue is filed or edited. The parser is tested standalone (below); the Actions wiring is not.
- **`renovate.json` is not here.** #50 pins an explicit config, #1 inherits the org one — mutually exclusive, and an open decision.
- **The heading match is a prefix**, which is what makes `bug_report.yml`'s long label work. Cost: a future `### Priority rationale` heading would also match and take its first word — confirmed, it yields `because`. No such heading exists in any form today; documented in the workflow file.
- Retroactive labelling of the 4 existing open issues is not done.

## Judgement calls

1. **Kept the filename `issue-priority-label.yml` even though it now does size too.** The synced doc refers to it by name; a more accurate filename would re-break the reference I am fixing. Comment at the top of the file says so.
2. **Extended the existing workflow rather than adding a second one.** One `on: issues` trigger, two label families; a second workflow would double the runs for no gain.
3. **Rewrote CLAUDE.md's Commands rather than deleting it.** "No build, no tests, the markdown is the artifact" is itself the useful instruction for an agent that would otherwise go looking for one.
4. **Created the `size:*` labels directly on the repo** rather than leaving it as an ops checkbox — the workflow is inert without them, and shipping a workflow that fails on first run is worse than not shipping it.

## Issues

Refs #50 — supersedes it. Recommend closing #50 once this lands; see the residual-risk list for what is deliberately left behind.

## Stacking / conflicts

Branched off `main` at `37c0ede`. No shared files with any open PR — #66 touches `SKILL.md` and `references/`, #1 touches `renovate.json`, neither of which is here.

## Verification evidence

**Parser, against four real body shapes.** The helper is the same `awk` the workflow runs:

```
=== against #62, a real form-filed issue ===
  Priority -> 'medium'   Size -> 'S'          # correct, that is what I selected

=== synthetic: full form body ===
  Priority -> 'critical' Size -> 'M'

=== bug_report shape: Size but NO Priority ===
  Priority -> ''         Size -> 'L'          # degrades, does not crash

=== free-form issue, no form at all ===
  Priority -> ''         Size -> ''
```

The two empty-Priority cases are the ones that matter: the workflow's `case` falls through to a skip message rather than calling `gh` with an empty label.

**Workflow parses:**

```
$ ruby -ryaml -e 'd=YAML.load_file(".github/workflows/issue-priority-label.yml"); puts d["name"]'
yaml OK: Label issue priority
```

**Labels now exist:**

```
$ gh label list | grep size:
size:S  size:M  size:L
```

**CLAUDE.md no longer references a package manager:**

```
$ grep -c 'npm run' CLAUDE.md
0
```

**Mutation count: N/A, and I will not dress it up.** This repo has no test harness (see #62), and the workflow is `on: issues` so CI cannot exercise it. The parser evidence above is a standalone run of the same `awk`, not a run of the workflow. The first real proof will be the next issue filed through the form.

## Remaining ops steps

- [x] `size:S` / `size:M` / `size:L` labels created on the repo
- [x] ~~File an upstream pm-kit issue to add a Priority dropdown to `bug_report.yml`~~ — not needed, it already has one (see corrected risk note)
- [ ] Close #50 once this merges
- [ ] Decide `renovate.json`: #1's org-inherited config, or #50's pinned one

## Questions for the maintainer

1. Want the 4 open issues (#23, #36, #39, #62) retro-labelled with sizes? The workflow only fires on `opened`/`edited`, so they stay unlabelled until touched.
2. `renovate.json` — #1 or #50's version? I can close whichever loses.

