### PR TITLE
docs(templates): document all four Celo Composer templates, not just minipay

### DIFF
--- a/skills/celopedia-skill/references/dev-templates.md
+++ b/skills/celopedia-skill/references/dev-templates.md
@@ -282,13 +282,62 @@ function SendCelo() {
 
 ## Scaffold a New Celo dApp
 
+### Celo Composer templates
+
+`-t` takes exactly four values. Anything else falls back to `basic` rather than erroring, so a
+typo scaffolds the wrong project silently — check what you got before building on it.
+
+| `-t` | Shape | What you get on top of the base | Wallet / contracts default |
+|------|-------|--------------------------------|----------------------------|
+| `basic` | monorepo (`apps/web`, `apps/contracts`) | Next.js + wagmi + viem + RainbowKit, Hardhat alongside | `rainbowkit` / `hardhat` |
+| `minipay` | monorepo (`apps/web`, `apps/contracts`) | `basic` **plus** MiniPay detection (`window.ethereum.isMiniPay`), auto-connect in the wallet provider and connect button, and a `user-balance.tsx` component | `rainbowkit` / `hardhat` |
+| `farcaster-miniapp` | monorepo (`apps/web` only) | `@farcaster/frame-sdk`, `frame-core`, `miniapp-wagmi-connector`, `quick-auth`, plus a `FARCASTER_SETUP.md` | `none` / `none` |
+| `ai-chat` | **single app at the repo root — not a monorepo** | Vercel AI SDK chat app: `@ai-sdk/{anthropic,google,mistral,openai,perplexity,react}`, artifacts, Drizzle + Postgres, auth, Playwright tests | `none` / `none` |
+
 ```bash
-# Full dApp with MiniPay template
+# Agent / chatbot — the AI SDK starter (no contracts, no wallet, needs a Postgres URL)
+npx @celo/celo-composer@latest create -t ai-chat
+
+# MiniPay Mini App — basic + MiniPay detection and auto-connect
 npx @celo/celo-composer@latest create -t minipay
 
-# With Thirdweb
+# Farcaster Mini App
+npx @celo/celo-composer@latest create -t farcaster-miniapp
+
+# Plain Celo dApp
+npx @celo/celo-composer@latest create -t basic
+
+# With Thirdweb (not Composer)
 npx thirdweb create app --evm
 ```
+
+**Compose the pieces independently of the template:**
+
+```bash
+--wallet-provider rainbowkit|thirdweb|none
+-c, --contracts   hardhat|foundry|none
+--skip-install    # scaffold only, no pnpm install
+-y                # accept defaults, no prompts
+```
+
+**Things worth knowing before you pick:**
+
+- **`ai-chat` is the odd one out.** It is not a monorepo and ships no contracts or wallet wiring —
+  it is the Vercel AI chat starter with Celo defaults, so a Celo transaction path is yours to add.
+  It also expects a Postgres database (Drizzle migrations run on `build`), which the other three
+  do not.
+- **`minipay` is `basic` plus a MiniPay layer**, not a separate lineage. If you already scaffolded
+  `basic`, you are ~5 files away from the `minipay` output rather than needing to start over.
+- **`farcaster-miniapp` has no `apps/contracts`.** Add one with `-c hardhat` if you need it.
+- For a MiniPay Mini App you may not want Composer at all — see
+  `minipay-scaffold-from-scratch.md` for a single-app Next.js + viem setup.
+
+> Verified 2026-09-02 against `@celo/celo-composer@2.4.13` (node v20.19.4, darwin): all four
+> scaffold with exit 0. File counts — `basic` 32, `minipay` 33, `farcaster-miniapp` 40,
+> `ai-chat` 173. The silent-fallback warning is measured, not assumed: `-t nonsense` also exits 0
+> and produces the same 32 files as `basic`. Template list taken from `create --help`, not from
+> the package's `templates/` directory, which also contains `contracts/` and `wallets/` — those
+> are the `-c` and `--wallet-provider` pieces, not `-t` values.
 
 ---
 


### PR DESCRIPTION
## The hole, and the fix

The skill pointed builders at `npx @celo/celo-composer@latest create -t minipay` in **five** places and never mentioned that any other template exists:

```
$ grep -rho -- '-t [a-z-]*' skills/ | sort | uniq -c
   5 minipay
```

Composer ships **four**: `basic`, `minipay`, `farcaster-miniapp`, `ai-chat`. The one that matters most right now is `ai-chat` — the **Agents at Work hackathon is running until Sep 14** and the agent starter was invisible to anyone reading the skill.

This documents all four: what each gives you on top of the base, the default wallet/contracts pairing each implies, and the composable flags (`--wallet-provider`, `-c`, `--skip-install`) that are independent of `-t`.

## What this does NOT do / residual risk

- **Scaffold-verified, not build-verified.** I ran `create` for all four and inspected the output tree and `package.json`. I did **not** run `pnpm install && pnpm dev` on each, so "these scaffold correctly" is the claim, not "these run". `ai-chat` in particular needs a Postgres URL before it will build — that's documented, not tested.
- **Pinned to one version and one platform**: `@celo/celo-composer@2.4.13`, node v20.19.4, darwin/arm64. The file records that. Composer has had one release in ~8 months, so it should hold, but a future template change won't be caught by anything here — nothing in this repo tests scaffolding (see #62).
- **No new MiniPay guidance.** `minipay-scaffold-from-scratch.md` remains the recommendation for Mini Apps; this only adds a pointer.
- Doesn't document Composer's interactive prompt flow, only the flag-driven one.

## Judgement calls

1. **Four templates, not six — I got this wrong first and corrected it.** My initial pass read the package's `templates/` directory (`ai`, `base`, `contracts`, `farcaster-miniapp`, `minipay`, `wallets`) and concluded six. `create --help` is authoritative and says four; `contracts/` and `wallets/` are the `-c` and `--wallet-provider` pieces. Documented as four, with a note in the file about why the directory listing misleads, so nobody repeats the mistake.
2. **Called out the silent fallback prominently.** An invalid `-t` doesn't error — it scaffolds `basic` and exits 0. That's the failure a typo produces and it doesn't announce itself, so it leads the section rather than sitting in a footnote.
3. **Described `minipay` as "`basic` plus a layer"** rather than as its own thing, because the diff says so. That tells someone who already scaffolded `basic` they're ~5 files away rather than needing to restart.
4. **Left the five existing `-t minipay` references alone.** They're correct in context; this adds the map rather than rewriting the pointers.

## Issues

Refs #23 — but note the premise correction below rather than treating this as its fix.

#23 claims the Celopedia references point builders at the `ai-chat` template. **They never have:**

```
$ git log -S'ai-chat' --all -- skills/
(no commits)
```

The ENOENT in #23 also **no longer reproduces** — I re-ran the exact command on the same environment reported there (node v20.19.4, darwin) and it scaffolds the genuine ai-chat template, exit 0, despite the version being unchanged at 2.4.13. Full evidence is on the issue, including the latent depth-dependency that's still in the shipped resolver. That fix belongs in `@celo/celo-composer`. **This PR closes the real gap behind #23 — the missing documentation — not the upstream bug.**

## Stacking / conflicts

Branched off `main` at `37c0ede`. Independent of #66 (`SKILL.md`, `agent-security.md`) and #67 (`CLAUDE.md`, workflow) — no shared files.

## Verification evidence

**All four scaffold**, `create <name> -t <t> -y --skip-install`:

```
basic              exit=0 files=32   README.md apps package.json pnpm-workspace.yaml tsconfig.json turbo.json
minipay            exit=0 files=33   README.md apps package.json pnpm-workspace.yaml tsconfig.json turbo.json
farcaster-miniapp  exit=0 files=40   FARCASTER_SETUP.md README.md apps package.json ... turbo.json
ai-chat            exit=0 files=173  LICENSE README.md app artifacts biome.jsonc components ... tests
```

**`ai-chat` is genuinely different**, not a fallback — full install run separately, exit 0:

```
app/(chat)/  app/(auth)/  artifacts/  drizzle.config.ts  playwright.config.ts
deps: @ai-sdk/{anthropic,google,mistral,openai,perplexity,react}, ai, drizzle-orm
```

**`minipay` = `basic` + a MiniPay layer**, from `diff -rq`:

```
Only in app-minipay: apps/web/src/components/user-balance.tsx
differ: layout.tsx, page.tsx, connect-button.tsx, navbar.tsx, wallet-provider.tsx
  > const [isMinipay, setIsMinipay] = useState(false);
  > if (window.ethereum?.isMiniPay) {
```

**`farcaster-miniapp` has no contracts app**, and carries the Farcaster SDK:

```
apps/: web            (basic and minipay both have: contracts web)
deps: @farcaster/frame-core, frame-sdk, miniapp-wagmi-connector, quick-auth
```

**The silent-fallback claim is measured, not reasoned:**

```
$ npx @celo/celo-composer@latest create app-bogus -t nonsense -y --skip-install
🎉 Your Celo project is ready!   exit=0
files=32, same top-level tree as basic
```

**Template list is from the CLI, not a directory listing:**

```
$ npx @celo/celo-composer@latest create --help
  -t, --template <type>   Template type (basic, farcaster-miniapp, minipay, ai-chat)
```

**Mutation count: N/A.** This repo has no test harness (#62) and the change is documentation. The evidence above is the artifact being run, which is the closest thing available — every claim in the new section maps to one of these commands.

## Remaining ops steps

- [ ] Close #23 as not-reproducible (evidence posted on the issue)

## Questions for the maintainer

1. Worth a pointer to `-t ai-chat` from `ai-agents.md` too, given the hackathon? I kept this to one file to stay single-concern.
2. `ai-chat` needs a Postgres URL to build. Worth documenting the setup, or is that upstream's README's job?
